### PR TITLE
Add missing mlid daemon

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -601,6 +601,9 @@ vendor/lib/libOmxSwVdec.so
 vendor/lib/libOmxSwVencMpeg4.so
 vendor/lib/libOmxWmaDec.so
 
+# Mink-Lowi Interface daemon
+vendor/bin/mlid
+
 # Mlipay
 vendor/bin/mlipayd@1.1
 vendor/etc/init/vendor.xiaomi.hardware.mlipay@1.1-service.rc


### PR DESCRIPTION
Mink-Lowi Interface daemon (mlid) is started from init.qcom.rc but in fact it is not present in proprietary-files.txt.