### PR TITLE
GPS: Missing configuration files and bugfix

### DIFF
--- a/gps/core/SystemStatus.cpp
+++ b/gps/core/SystemStatus.cpp
@@ -660,6 +660,7 @@ private:
     {
         eTalker = 0,
         eUtcTime = 1,
+        eMin = 2 + SV_ALL_NUM_MIN*3,
         eMax = 2 + SV_ALL_NUM*3
     };
     SystemStatusPQWP7 mP7;
@@ -668,11 +669,18 @@ public:
     SystemStatusPQWP7parser(const char *str_in, uint32_t len_in)
         : SystemStatusNmeaBase(str_in, len_in)
     {
-        if (mField.size() < eMax) {
+        uint32_t svLimit = SV_ALL_NUM;
+        if (mField.size() < eMin) {
             LOC_LOGE("PQWP7parser - invalid size=%zu", mField.size());
             return;
         }
-        for (uint32_t i=0; i<SV_ALL_NUM; i++) {
+        if (mField.size() < eMax) {
+            // Try reducing limit, accounting for possibly missing NAVIC support
+            svLimit = SV_ALL_NUM_MIN;
+        }
+
+        memset(mP7.mNav, 0, sizeof(mP7.mNav));
+        for (uint32_t i=0; i<svLimit; i++) {
             mP7.mNav[i].mType   = GnssEphemerisType(atoi(mField[i*3+2].c_str()));
             mP7.mNav[i].mSource = GnssEphemerisSource(atoi(mField[i*3+3].c_str()));
             mP7.mNav[i].mAgeSec = atoi(mField[i*3+4].c_str());

--- a/gps/core/SystemStatus.h
+++ b/gps/core/SystemStatus.h
@@ -59,7 +59,8 @@
 #define BDS_NUM     (37)
 #define GAL_NUM     (36)
 #define NAVIC_NUM   (14)
-#define SV_ALL_NUM  (GPS_NUM+GLO_NUM+QZSS_NUM+BDS_NUM+GAL_NUM+NAVIC_NUM) //=148
+#define SV_ALL_NUM_MIN  (GPS_NUM + GLO_NUM + QZSS_NUM + BDS_NUM + GAL_NUM) //=134
+#define SV_ALL_NUM      (SV_ALL_NUM_MIN + NAVIC_NUM) //=148
 
 namespace loc_core
 {

--- a/gps/etc/apdr.conf
+++ b/gps/etc/apdr.conf
@@ -1,0 +1,205 @@
+# AP DR SENSOR Configuration file
+#
+# SENSOR_SERVICE options are one of below
+#   accel,gyro,vehicle_accel,vehicle_gyro,pedometer,vehicle_odometry,accel_temp,
+#   gyro_temp,baro,mag_calib,mag_uncalib,amd,rmd.
+#
+# SENSOR_PROVIDER options is one of -- default,native,ssc,samlite.
+#
+# SENSOR_RATE = 1~100 (Hz)
+#
+# SENSOR_SAMPLES = 1~N
+#
+# SENSOR_STATISTIC_ENABLED
+#  bit 0: Diag Print Enabled
+#  bit 1: Adb  Print Enabled
+# SENSOR_STATISTIC_PRINT_COUNT
+#  Skip Number of Print
+#
+# QDR_DYNAMIC_LOADING = 1~3
+# Configure QDR library to be loaded
+#   1: QDR3
+#   2: QDR2-GYRO
+#   3: QDR2-DWT
+#
+#
+
+
+######################################
+#                                    #
+#   Default Configuration            #
+#  (GNSS only,QDR Disabled)          #
+#                                    #
+# For QDR enablement, comment        #
+# this section and enabled           #
+# either QDR3 OR                     #
+# QDR2-DWT OR QDR2-Gyro related      #
+# configuration section in below.    #
+#                                    #
+######################################
+
+SENSOR_SERVICE = accel
+SENSOR_PROVIDER = native
+SENSOR_RATE = 100
+SENSOR_SAMPLES = 1
+
+SENSOR_SERVICE = gyro
+SENSOR_PROVIDER = native
+SENSOR_RATE = 100
+SENSOR_SAMPLES = 1
+
+SENSOR_SERVICE = vehicle_gear
+SENSOR_PROVIDER = native
+SENSOR_RATE = 100
+SENSOR_SAMPLES = 1
+
+
+######################################
+#                                    #
+#   QDR3 Configuration               #
+#                                    #
+# For QDR3,                          #
+# comment default configuration above#
+# and                                #
+# uncomment below configuration      #
+# settings.                          #
+#                                    #
+######################################
+#
+#SENSOR_SERVICE = accel
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 10
+#SENSOR_SAMPLES = 10
+#
+#SENSOR_SERVICE = vehicle_speed
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#
+#SENSOR_SERVICE = gyro
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 10
+#SENSOR_SAMPLES = 10
+#
+#SENSOR_SERVICE = vehicle_gear
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#
+#
+##Enable/disable sensor data flashback feature
+#QDR_FLASHBACK_ENABLED = 0
+##Configure QDR library to be loaded 1: QDR3 2: QDR2-GYRO 3: QDR2-DWS
+#QDR_DYNAMIC_LOADING = 1
+##Enable/disable sensor data batching feature
+#QDR_BATCHING_ENABLED = 2
+##Reporting offset before PPS boundary
+#QDR_REPORTING_OFFSET = 0
+##Sensor dispatch threshold declaration
+#QDR_SENSDISPATCH_MS = 30
+#
+
+######################################
+#                                    #
+#   QDR2-DWT Configuration           #
+#                                    #
+# For QDR2-DWT,                      #
+# comment default configuration above#
+# and                                #
+# uncomment below configuration      #
+# settings.                          #
+#                                    #
+######################################
+#
+#SENSOR_SERVICE = vehicle_speed
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#SENSOR_STATISTIC_ENABLED = 3
+#SENSOR_STATISTIC_PRINT_COUNT = 50
+#
+#SENSOR_SERVICE = vehicle_dws
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#SENSOR_STATISTIC_ENABLED = 3
+#SENSOR_STATISTIC_PRINT_COUNT = 50
+#
+#SENSOR_SERVICE = vehicle_gear
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#SENSOR_STATISTIC_ENABLED = 3
+#SENSOR_STATISTIC_PRINT_COUNT = 50
+#
+#GNSS_POS_STATISTIC_ENABLED = 3
+#GNSS_POS_STATISTIC_PRNTCNT = 10
+#GNSS_MSR_STATISTIC_ENABLED = 3
+#GNSS_MSR_STATISTIC_PRNTCNT = 10
+#
+##Enable/disable sensor data flashback feature
+#QDR_FLASHBACK_ENABLED = 0
+##Configure QDR library to be loaded 1: QDR3 2: QDR2-GYRO 3: QDR2-DWS
+#QDR_DYNAMIC_LOADING = 3
+##Enable/disable sensor data batching feature
+#QDR_BATCHING_ENABLED = 0
+##Reporting offset before PPS boundary
+#QDR_REPORTING_OFFSET = 0
+##Sensor dispatch threshold declaration
+#QDR_SENSDISPATCH_MS = 30
+##QDR_ENABLE_QG shall be set as 1
+#QDR_ENABLE_QG = 1
+##Select Wheel set (E.g.: Front two wheels, Rear two wheels OR All four wheels)
+##To be used for differential wheel tick OR speed service.
+##This configuration is applicable when QDR_CAN_TYPE configured as
+##ODO_DWS(3) or ODO_DWT(2).
+##Value "0": Use Front two wheels
+##Value "1": Use Rear two wheels
+##Value "2": Use All four wheels
+#QG_DRIVE_WHEEL_FW_RW_AW = 2
+##Max Wheel tick value above which wheel tick rolls over
+##This configuration is applicable when QDR_CAN_TYPE configured as ODO_DWT(2)
+#QG_DWT_MAX_WHEEL_TICK_COUNT = 255.0
+##Configure Wheel constant for DWT based below equation
+##(2 * pi * WHEEL_RADIUS / Pulses Per revolution)
+##This configuration is applicable when QDR_CAN_TYPE configured as ODO_DWT(2)
+#QG_DWT_WHEEL_CONSTANT = 0.044
+
+######################################
+#                                    #
+#   QDR2-GYRO Configuration          #
+#                                    #
+# For QDR2-GYRO,                     #
+# comment default configuration above#
+# and                                #
+# uncomment below configuration      #
+# settings.                          #
+#                                    #
+######################################
+#
+#SENSOR_SERVICE = vehicle_speed
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#
+#SENSOR_SERVICE = vehicle_gyro
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#
+#SENSOR_SERVICE = vehicle_gear
+#SENSOR_PROVIDER = native
+#SENSOR_RATE = 100
+#SENSOR_SAMPLES = 1
+#
+##Enable/disable sensor data flashback feature
+#QDR_FLASHBACK_ENABLED = 0
+##Configure QDR library to be loaded 1: QDR3 2: QDR2-GYRO 3: QDR2-DWS
+#QDR_DYNAMIC_LOADING = 2
+##Enable/disable sensor data batching feature
+#QDR_BATCHING_ENABLED = 0
+##Reporting offset before PPS boundary
+#QDR_REPORTING_OFFSET = 0
+##Sensor dispatch threshold declaration
+#QDR_SENSDISPATCH_MS = 30
+#

--- a/gps/etc/gps.conf
+++ b/gps/etc/gps.conf
@@ -11,10 +11,12 @@ XTRA_VERSION_CHECK=0
 ERR_ESTIMATE=0
 
 #NTP server
-NTP_SERVER=time.izatcloud.net
+NTP_SERVER=time.xtracloud.net
+NTP_SERVER_2=asia.pool.ntp.org
+NTP_SERVER_3=0.cn.pool.ntp.org
 
 #XTRA CA path
-XTRA_CA_PATH=/usr/lib/ssl/certs
+XTRA_CA_PATH=/system/etc/security/cacerts
 
 # DEBUG LEVELS: 0 - none, 1 - Error, 2 - Warning, 3 - Info
 #               4 - Debug, 5 - Verbose
@@ -22,13 +24,13 @@ XTRA_CA_PATH=/usr/lib/ssl/certs
 DEBUG_LEVEL = 3
 
 # Intermediate position report, 1=enable, 0=disable
-INTERMEDIATE_POS=0
+INTERMEDIATE_POS=1
 
 # supl version 1.0
-SUPL_VER=0x10000
+SUPL_VER=0x20000
 
 # Emergency SUPL, 1=enable, 0=disable
-#SUPL_ES=1
+#SUPL_ES=0
 
 #Choose PDN for Emergency SUPL
 #1 - Use emergency PDN
@@ -40,7 +42,7 @@ SUPL_VER=0x10000
 #config.xml.
 #MSA=0X2
 #MSB=0X1
-#SUPL_MODE=
+SUPL_MODE=3
 
 # GPS Capabilities bit mask
 # SCHEDULING = 0x01
@@ -52,15 +54,15 @@ CAPABILITIES=0x17
 
 # Accuracy threshold for intermediate positions
 # less accurate positions are ignored, 0 for passing all positions
-# ACCURACY_THRES=5000
+ACCURACY_THRES=70
 
 ################################
 ##### AGPS server settings #####
 ################################
 
 # FOR SUPL SUPPORT, set the following
-# SUPL_HOST=supl.host.com or IP
-# SUPL_PORT=1234
+SUPL_HOST=supl.qxwz.com
+SUPL_PORT=7275
 
 # FOR MO SUPL SUPPORT, set the following
 # MO_SUPL_HOST=supl.host.com or IP
@@ -85,7 +87,7 @@ CAPABILITIES=0x17
 # 1: Enable LPP_User_Plane on LTE
 # 2: Enable LPP_Control_Plane
 # 3: Enable both LPP_User_Plane and LPP_Control_Plane
-LPP_PROFILE = 2
+LPP_PROFILE = 0
 
 ####################################
 #Datum Type
@@ -215,6 +217,10 @@ MISSING_PULSE_TIME_DELTA = 900
 # logic incase of missing PPS pulse
 PROPAGATION_TIME_UNCERTAINTY = 1
 
+XTRA_TEST_ENABLED = 1
+XTRA_THROTTLE_ENABLED = 0
+XTRA_SYSTEM_TIME_INJECT = 1
+
 #######################################
 #  APN / IP Type Configuration
 #  APN and IP Type to use for setting
@@ -271,7 +277,7 @@ MODEM_TYPE = 1
 # 1 : enabled
 # This setting enables GPS engine to estimate clock
 # bias and drift when the signal from at least 1
-# SV is available and the UE’s position is known by
+# SV is available and the UE's position is known by
 # other position engines.
 #POSITION_ASSISTED_CLOCK_ESTIMATOR_ENABLED = 0
 

--- a/gps/etc/gps.conf
+++ b/gps/etc/gps.conf
@@ -11,9 +11,10 @@ XTRA_VERSION_CHECK=0
 ERR_ESTIMATE=0
 
 #NTP server
-NTP_SERVER=time.xtracloud.net
-NTP_SERVER_2=asia.pool.ntp.org
-NTP_SERVER_3=0.cn.pool.ntp.org
+NTP_SERVER=pool.ntp.org
+NTP_SERVER_2=europe.pool.ntp.org
+NTP_SERVER_3=north-america.pool.ntp.org
+NTP_SERVER_4=asia.pool.ntp.org
 
 #XTRA CA path
 XTRA_CA_PATH=/system/etc/security/cacerts

--- a/gps/etc/izat.conf
+++ b/gps/etc/izat.conf
@@ -1,0 +1,252 @@
+#########################################
+# Log verbosity control for izat modules
+#########################################
+# OFF = 0, ERROR = 1, WARNING = 2, INFO = 3, DEBUG = 4, VERBOSE = 5
+IZAT_DEBUG_LEVEL = 2
+
+##################################################
+# Select WIFI Wait Timeout value in seconds for SUPL
+##################################################
+WIFI_WAIT_TIMEOUT_SELECT = 0
+
+##################################################
+# Time interval of injecting SRN scan data to modem
+# time in seconds.
+# Note: recommended value is between 1-5 sec
+##################################################
+LPPE_SRN_DATA_SCAN_INJECT_TIME=2
+
+################################
+# NLP Settings
+################################
+# NLP_MODE  1: OSNLP Only, 2: QNP Only, 3: Combo, 4: QNP preferred
+# For Automotive products, please use NLP_MODE = 4 only.
+# NLP_TOLERANCE_TIME_FIRST: Time in ms used in Combo mode
+# to determine how much Tolerance for first position
+# NLP_TOLERANCE_TIME_AFTER: Time in ms used in Combo mode
+# to determine how much Tolerance for positions after first
+# NLP_THRESHOLD: Sets how many failures needed before
+# switching preferred NLP in Combo mode
+# NLP_ACCURACY_MULTIPLE: Determines how far off the accuracy
+# must be, in multiples, between two NLP location reports to
+# be considered much worse accuracy. Used in switching logic
+# NLP COMBO MODE USES QNP WITH NO EULA CONSENT: Determines
+# whether or not to still send network location requests to
+# QNP when the EULA is not consented to by the user. QNP can
+# still return ZPP locations or injected locations even
+# without EULA consent, but the uncertainty can be high.
+# QNP preferred mode prefers QNP when there is EULA consent,
+# otherwise OSNLP is used.
+NLP_MODE = 1
+NLP_MODE_EMERGENCY = 2
+NLP_TOLERANCE_TIME_FIRST = 5000
+NLP_TOLERANCE_TIME_AFTER = 20000
+NLP_THRESHOLD = 3
+NLP_ACCURACY_MULTIPLE = 2
+NLP_COMBO_MODE_USES_QNP_WITH_NO_EULA_CONSENT = 1
+
+#########################################
+# NLP PACKAGE SETTINGS
+#########################################
+# OSNLP_PACKAGE: name of default NLP package
+OSNLP_PACKAGE = com.google.android.gms
+# REGION_OSNLP_PACKAGE:
+# This value will be used as alternative
+# for particular region where default NLP is not functional.
+#REGION_OSNLP_PACKAGE =
+
+###################################
+# GEOFENCE SERVICES
+###################################
+# If set to one of the defined values below, it will override
+# the responsiveness for geofence services, which implements
+# the Proximity Alert API. If not set to a value defined below,
+# which is default, it will not override the responsivness.
+# The geofence HAL API is unaffected by this value.
+# GEOFENCE_SERVICES_RESPONSIVENESS_OVERRIDE Values:
+# 1: LOW responsiveness
+# 2: MEDIUM responsiveness
+# 3: HIGH responsiveness
+GEOFENCE_SERVICES_RESPONSIVENESS_OVERRIDE = 0
+
+#####################################
+#GTP Opt-In app
+#####################################
+
+#GTP privacy policy version url
+#https support is required
+GTP_PRIVACY_VERSION_URL = https://info.izatcloud.net/privacy/version.html
+
+#GTP privacy policy version download retry interval
+#unit is second. default is 86400
+GTP_PRIVACY_RETRY_INTERVAL = 86400
+
+#####################################
+# IZAT PREMIUM FEATURE SETTINGS
+#####################################
+#Possible states of a feature:
+#DISABLED
+#BASIC
+#PREMIUM
+
+#GTP_MODE valid modes:
+# DISABLED
+# LEGACY_WWAN
+# SDK (WWAN not available for Modems before LocTech 10.0)
+GTP_MODE=DISABLED
+
+#GTP_WAA valid modes:
+# DISABLED
+# BASIC
+GTP_WAA=DISABLED
+
+#SAP valid modes:
+# DISABLED
+# BASIC
+# PREMIUM
+SAP=PREMIUM
+# MODEM_DEFAULT(grease/bsp-SDM710.spf.2.1-000090)
+#SAP=MODEM_DEFAULT
+
+#FREE_WIFI_SCAN_INJECT valid modes:
+#DISABLED
+#BASIC
+FREE_WIFI_SCAN_INJECT=BASIC
+
+#SUPL_WIFI valid modes:
+#DISABLED
+#BASIC
+SUPL_WIFI=BASIC
+
+#WIFI_SUPPLICANT_INFO valid modes:
+#DISABLED
+#BASIC
+WIFI_SUPPLICANT_INFO=BASIC
+
+#####################################
+# Location process launcher settings
+#####################################
+
+# DO NOT MODIFY
+# Modifying below attributes without
+# caution can have serious implications.
+
+#Values for PROCESS_STATE:
+# ENABLED
+# DISABLED
+
+#PROCESS_NAME
+# Name of the executable file.
+
+#FEATURE MASKS:
+# GTP-WIFI    0X03
+# GTP-MP-CELL 0xc00
+# GTP-WAA     0x100
+# SAP         0Xc0
+# ODCPI      0x1000
+# FREE_WIFI_SCAN_INJECT   0x2000
+# SUPL_WIFI   0x4000
+# WIFI_SUPPLICANT_INFO   0x8000
+
+#Values for PLATFORMS can be:
+#1. Any valid values obtained from ro.board.platform separated by single space. For example: msm8960 msm8226
+#2. 'all' or 'all exclude' -> for All platforms
+#3. 'all exclude XXXX' -> All platforms exclude XXXX. For example: all exclude msm8937
+
+#Values for BASEBAND can be:
+#1. Any valid values obtained from ro.baseband separated by single space. For example: sglte sglte2
+#2. 'all' or 'all exclude' -> for all basebands
+#3. 'all exclude XXXX' -> All basebands exclude XXXX. For example: all exclude sglte
+PROCESS_NAME=lowi-server
+PROCESS_ARGUMENT=
+PROCESS_STATE=ENABLED
+PROCESS_GROUPS=gps wifi inet oem_2901
+PREMIUM_FEATURE=0
+IZAT_FEATURE_MASK=0xf303
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=0
+
+PROCESS_NAME=xtwifi-inet-agent
+PROCESS_ARGUMENT=
+PROCESS_STATE=ENABLED
+PROCESS_GROUPS=inet gps
+PREMIUM_FEATURE=1
+IZAT_FEATURE_MASK=0xc03
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=1
+
+PROCESS_NAME=xtwifi-client
+PROCESS_ARGUMENT=
+PROCESS_STATE=ENABLED
+PROCESS_GROUPS=wifi inet gps system oem_2904
+PREMIUM_FEATURE=1
+IZAT_FEATURE_MASK=0xd03
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=1
+
+PROCESS_NAME=slim_daemon
+PROCESS_ARGUMENT=
+PROCESS_STATE=DISABLED
+PROCESS_GROUPS=gps oem_2901 can plugdev diag sensors
+PREMIUM_FEATURE=1
+IZAT_FEATURE_MASK=0xf0
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=1
+
+PROCESS_NAME=xtra-daemon
+PROCESS_ARGUMENT=
+PROCESS_STATE=ENABLED
+PROCESS_GROUPS=inet gps system
+PREMIUM_FEATURE=0
+IZAT_FEATURE_MASK=0
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=0
+
+########################################
+# Engine Service which host DRE module #
+# To enable DRE engine service, change #
+# PROCESS_STATE=ENABLED                #
+########################################
+PROCESS_NAME=engine-service
+PROCESS_ARGUMENT=DRE-INT libloc_epDr.so
+PROCESS_STATE=DISABLED
+PROCESS_GROUPS=gps diag inet qwes oem_2901 system
+PREMIUM_FEATURE=0
+IZAT_FEATURE_MASK=0
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=1
+
+########################################
+# Engine Service which host PPE module #
+# To enable PPE engine service, change #
+# PROCESS_STATE=ENABLED                #
+# and update process arugements        #
+# with PPE library name                #
+#PROCESS_ARGUMENT=PPE libepsimulator.so#
+########################################
+PROCESS_NAME=engine-service
+PROCESS_ARGUMENT=PPE libepsimulator.so
+PROCESS_STATE=DISABLED
+PROCESS_GROUPS=gps diag inet oem_2901
+PREMIUM_FEATURE=0
+IZAT_FEATURE_MASK=0
+PLATFORMS=all
+BASEBAND=all
+HARDWARE_TYPE=all
+VENDOR_ENHANCED_PROCESS=1
+
+#Accuracy threshold for ZPP positions
+# less accurate positions are ignored
+ZPP_ACCURACY_THRESHOLD=1000

--- a/gps/etc/lowi.conf
+++ b/gps/etc/lowi.conf
@@ -1,0 +1,27 @@
+#*====*====*====*====*====*====*====*====*====*====*====*====*====*====*====*
+#
+# LOWI Config file
+#
+# GENERAL DESCRIPTION
+#  This file contains the config params for LOWI
+#
+# Copyright (c) 2019 Qualcomm Technologies, Inc.
+#  All Rights Reserved.
+#  Confidential and Proprietary - Qualcomm Technologies, Inc.
+#
+# 2012-2013 Qualcomm Atheros, Inc.
+#  All Rights Reserved.
+#  Qualcomm Atheros Confidential and Proprietary.
+#
+# Export of this technology or software is regulated by the U.S. Government.
+# Diversion contrary to U.S. law prohibited.
+#=============================================================================*/
+
+# X86 ONLY - UBUNTU:
+# Copy this file in the same directory where the executable is
+
+# Log level
+# EL_LOG_OFF = 0, EL_ERROR = 1, EL_WARNING = 2, EL_INFO = 3, EL_DEBUG = 4, EL_VERBOSE = 5, EL_LOG_ALL = 100
+LOWI_LOG_LEVEL = 3
+LOWI_USE_LOWI_LP = 0
+

--- a/gps/etc/sap.conf
+++ b/gps/etc/sap.conf
@@ -1,0 +1,161 @@
+################################
+# Sensor Settings
+################################
+#The following parameters are optional.
+#Internal defaults support MEMS sensors
+#native to most handset devices.
+#Device specific sensor characterization
+#for improved performance is possible as
+#described in SAP application notes.
+#GYRO_BIAS_RANDOM_WALK=
+#ACCEL_RANDOM_WALK_SPECTRAL_DENSITY=
+#ANGLE_RANDOM_WALK_SPECTRAL_DENSITY=
+#RATE_RANDOM_WALK_SPECTRAL_DENSITY=
+#VELOCITY_RANDOM_WALK_SPECTRAL_DENSITY=
+
+# Sensor Sampling Rate Parameters for Low-Data Rate Filter (should be greater than 0)
+# used in loc_eng_reinit
+SENSOR_ACCEL_BATCHES_PER_SEC=2
+SENSOR_ACCEL_SAMPLES_PER_BATCH=5
+SENSOR_GYRO_BATCHES_PER_SEC=2
+SENSOR_GYRO_SAMPLES_PER_BATCH=5
+# Sensor Sampling Rate Parameters for High-Data Rate Filter (should be greater than 0)
+SENSOR_ACCEL_BATCHES_PER_SEC_HIGH=4
+SENSOR_ACCEL_SAMPLES_PER_BATCH_HIGH=25
+SENSOR_GYRO_BATCHES_PER_SEC_HIGH=4
+SENSOR_GYRO_SAMPLES_PER_BATCH_HIGH=25
+
+# Sensor Control Mode (0=AUTO, 1=FORCE_ON, 2=MODEM_DEFAULT)
+# used in loc_eng_reinit
+SENSOR_CONTROL_MODE=1
+
+# Bit mask used to define which sensor algorithms are used.
+# Setting each bit has the following definition:
+#  0x1 - DISABLE_INS_POSITIONING_FILTER
+#  0x0 - ENABLE_INS_POSITIONING_FILTER
+SENSOR_ALGORITHM_CONFIG_MASK=0x0
+
+#Vehicle Network Provider configuration
+
+#Service configuration strings
+#The number before colon in VN_X items defines version of the format of the rest of the string
+#VN_ACCEL_CFG=0:5
+#VN_GYRO_CFG=0:5.5
+#VN_ODOMETRY_CFG=0:2,4.5
+
+################################################
+#  QDR3 configurations                         #
+################################################
+VN_SPEED_CFG=1:131,5,8,1,2,3,1,1,9,2,14,2
+VN_GEAR_CFG=1:422,20,4,0,4,1,9,0,1,2,3,4,5,6,7,8
+
+################################################
+#  QDR2-Gyro configurations                    #
+################################################
+#VN_GYRO_CFG=1:555,0,1,0,0,0,0,-6.5,6.6066,-6.5,-1.00,2,6.607,6.6068,0,0,16,0.0002,0,16,0.0002,0,16,0.0002
+#VN_SPEED_CFG=1:555,0,0,1,2,1,0.01,0,56,8,48,8
+#VN_GEAR_CFG=1:555,16,4,0,1,1,9,0,1,2,3,4,5,6,7,8
+
+################################################
+#  QDR2-DWT configurations                     #
+################################################
+#VN_SPEED_CFG=1:555,22,1,2,1,1,1,0,8,8,23,1,2,0,1,0,8,8,23,1
+#VN_GEAR_CFG=1:555,12,4,16,14,16,8,1,2,3,4,5,6,7,8
+#VN_DWS_CFG=1:555,0,0,1,3,1,1,0,0,8,0,0,8,8,0,0,16,8,0,0,24,8,0,0
+#VN_GYRO_CFG=1:555,40,16,1.0,40,16,1.0,40,16,1.0
+
+#####################################################################################
+#                    VNW service batching configuration strings                     #
+# VNW provider will initialize default type as Time based batching                  #
+# Each service batch value is configured to be 100                                  #
+# VN_ACCEL_CFG_BATCH_VALUE will be treated as time in Ms if VN_CFG_BATCH_TYPE       #
+# is set to time based batching                                                     #
+# VN_ACCEL_CFG_BATCH_VALUE will be treated as sample count if VN_CFG_BATCH_TYPE     #
+# is set to count based batching                                                    #
+# Uncomment and update batch time /sample count as per selected batching type       #
+#####################################################################################
+# Batching type
+# 1 - Time based  (default)
+# 2 - Count based
+#VN_CFG_BATCH_TYPE=1
+
+#Vehicle Accel batching value, it can either accept time in milli seconds or sample count
+#VN_ACCEL_CFG_BATCH_VALUE=100
+
+#Vehicle Gyro batching value, it can either accept time in milli seconds or sample count
+#VN_GYRO_CFG_BATCH_VALUE=100
+
+#Vehicle Odo batching value, it can either accept time in milli seconds or sample count
+#VN_ODOMETRY_CFG_BATCH_VALUE=100
+
+#Vehicle Speed batching value, it can either accept time in milli seconds or sample count
+#VN_SPEED_CFG_BATCH_VALUE=100
+
+#Vehicle Gear batching value, it can either accept time in milli seconds or sample count
+#VN_GEAR_CFG_BATCH_VALUE=100
+
+#Vehicle DWS batching value, it can either accept time in milli seconds or sample count
+#VN_DWS_CFG_BATCH_VALUE=100
+####################################################################################
+
+#Procesors clock ratio: AP and CAN bus microcontroller
+################################################
+#  QDR3 configurations                         #
+################################################
+VN_PROC_CLOCK_RATIO=1.0
+
+################################################
+#  QDR2-DWT OR QDR2-Gyro configurations        #
+################################################
+#VN_PROC_CLOCK_RATIO = 1.0
+
+# Time source used by Sensor HAL
+# Setting this value controls accuracy of location sensor services.
+#  0 - Unknown
+#  1 - CLOCK_BOOTTIME
+#  2 - CLOCK_MONOTONIC
+#  3 - CLOCK_REALTIME
+#  4 - CLOCK_BOOTTIME using Alarm timer interface
+NDK_PROVIDER_TIME_SOURCE=1
+
+# Sensor Batching Configuration
+# 0 - Time based
+# 1 - Fixed count based
+# 2 - Variable count based
+COUNT_BASED_BATCHING=1
+SYNC_ONCE=0
+
+#Sensor HAL Provider Configuration HAL Library name including path
+################################################
+#                                              #
+# Configuration for BMI 160 Sensor             #
+#                                              #
+################################################
+SENSOR_TYPE=2
+SENSOR_HAL_LIB_PATH=/usr/lib/libbmi160sensors.so.1
+
+################################################
+#                                              #
+# Configuration for ASM330 Sensor              #
+#                                              #
+################################################
+#SENSOR_TYPE=1
+#SENSOR_HAL_LIB_PATH=/usr/lib/libasm330sensors.so.1
+
+
+################################################
+#                                              #
+# Configuration for IAM20680 Sensor            #
+#                                              #
+################################################
+#SENSOR_TYPE=3
+#SENSOR_HAL_LIB_PATH=/usr/lib/libiam20680sensors.so.1
+
+
+################################################
+#                                              #
+# Configuration for SMI130 Sensor              #
+#                                              #
+################################################
+#SENSOR_TYPE=4
+#SENSOR_HAL_LIB_PATH=/usr/lib/libsmi130sensors.so.1

--- a/gps/etc/xtwifi.conf
+++ b/gps/etc/xtwifi.conf
@@ -1,0 +1,78 @@
+#GTP AP Project client core config file
+#
+#GENERAL DESCRIPTION
+#This is used by client core
+#
+#Copyright (c) 2012-2014 Qualcomm Atheros, Inc.
+#All Rights Reserved.
+#Qualcomm Atheros Confidential and Proprietary.
+#
+#Copyright (c) 2017 Qualcomm Technologies, Inc.
+#All Rights Reserved.
+#Confidential and Proprietary - Qualcomm Technologies, Inc.
+
+##############################################################################
+# non-IOT devices configuration items                                        #
+# For non-IOT devices, configure below configuration items                   #
+# according to the app note: 80-NK218-1 and remove the configuration items   #
+# in section of "IOT devices configuration items".                           #
+##############################################################################
+
+# ASN URI v2 to be used by some GTP AP modules that
+# need to run with ASN URI v2 protocol.
+XT_SERVER_ROOT_URL = https://gtp1.izatcloud.net:443/uds/v2
+
+# ASN URI v3 to be used by GTP AP modules that
+# can support ASN URI v3 protocol.
+XT_SERVER_ROOT_URL_V3 = https://gtp1.izatcloud.net:443/uds/v3
+
+# size, in bytes, of the cache on device
+SIZE_BYTE_TOTAL_CACHE = 5000000
+
+##############################################################################
+# IOT devices configuration items                                            #
+# For IOT devices, configure below configuration items                       #
+# according to the app note and remove the configuration items in section of #
+# "non-IOT devices configuration items".                                     #
+##############################################################################
+
+# ASN URI v3 to be used by GTP AP modules that
+# can support ASN URI v3 protocol.
+# XT_SERVER_ROOT_URL_V3 = https://gtpma1.izatcloud.net:443/uds/v3
+
+# 3: Wi-Fi APDB injection via Izat SDK. GTP server is not accessed
+#    for any GTP requests, instead notification is sent to Izat SDK.
+#    WiFi crowdsourcing module is disabled.
+# 4: Wi-Fi APDB injection via Izat SDK. GTP server is not accessed
+#    for any GTP requests, instead notification is sent to Izat SDK.
+#    WiFi crowdsourcing module is active, also accessed via Izat SDK.
+# GTP_AP_MODE = 4
+
+# 1: MP cell features relies on GTP AP for either download or upload
+# 0: MP cell features does not rely on GTP AP
+# GTP_AP_NEEDED_BY_MP_CELL = 1
+
+##############################################################################
+# Configuration items applicable to all devices                              #
+##############################################################################
+
+# Log verbosity control for most of the GTP WiFi system, including native and
+# Java componenets
+# OFF = 0, ERROR = 1, WARNING = 2, INFO = 3, DEBUG = 4, VERBOSE = 5, ALL = 100
+DEBUG_GLOBAL_LOG_LEVEL = 2
+
+# this is used at the server side to distinguish uploads from different maker/model
+# default "Qualcomm"
+OEM_ID_IN_REQUEST_TO_SERVER = "Qualcomm"
+
+# this is used at the server side to distinguish uploads from different maker/model
+# default "UNKNOWN"
+MODEL_ID_IN_REQUEST_TO_SERVER = "UNKNOWN"
+
+##############################################################################
+# Qualcomm Network Location Provider config                                  #
+##############################################################################
+
+# Accuracy Threshold for NLP position. Position exceeds thsi threshold will be filtered out.
+# Default is 25000 meters.
+LARGE_ACCURACY_THRESHOLD_TO_FILTER_NLP_POSITION = 25000

--- a/manifest.xml
+++ b/manifest.xml
@@ -455,7 +455,9 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <hal format="hidl">
         <name>vendor.qti.gnss</name>
         <transport>hwbinder</transport>
-        <version>2.0</version>
+        <version>1.2</version>
+        <version>2.1</version>
+        <version>3.0</version>
         <interface>
                 <name>ILocHidlGnss</name>
                 <instance>gnss_vendor</instance>

--- a/sdm710.mk
+++ b/sdm710.mk
@@ -173,8 +173,13 @@ PRODUCT_PACKAGES += \
     android.hardware.gnss@2.0-service-qti
 
 PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/gps/etc/apdr.conf:$(TARGET_COPY_OUT_VENDOR)/etc/apdr.conf \
     $(LOCAL_PATH)/gps/etc/flp.conf:$(TARGET_COPY_OUT_VENDOR)/etc/flp.conf \
-    $(LOCAL_PATH)/gps/etc/gps.conf:$(TARGET_COPY_OUT_VENDOR)/etc/gps.conf
+    $(LOCAL_PATH)/gps/etc/gps.conf:$(TARGET_COPY_OUT_VENDOR)/etc/gps.conf \
+    $(LOCAL_PATH)/gps/etc/izat.conf:$(TARGET_COPY_OUT_VENDOR)/etc/izat.conf \
+    $(LOCAL_PATH)/gps/etc/lowi.conf:$(TARGET_COPY_OUT_VENDOR)/etc/lowi.conf \
+    $(LOCAL_PATH)/gps/etc/sap.conf:$(TARGET_COPY_OUT_VENDOR)/etc/sap.conf \
+    $(LOCAL_PATH)/gps/etc/xtwifi.conf:$(TARGET_COPY_OUT_VENDOR)/etc/xtwifi.conf
 
 # Health
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Next round of GPS fixes...

Commit 1 - added back configuration files that were removed by mistake by my previous update

Commit 2 - replaces default NTP servers by global ones from NTP.org pool

Commit 3 - fixes manifest for vendor.qti.gnss that supports major versions 1.2, 2.1 and 3.0 instead of current 2.0

Commit 4 - fix for GNSS engines that does not support NAVIC (sdm710 devices are affected)
                   Error message: "E LocSvc_SystemStatus: PQWP7parser - invalid size=404"

Thanks Alex for testing on 'sirius'.