### PR TITLE
Fix SELinux denials

### DIFF
--- a/sepolicy/vendor/domain.te
+++ b/sepolicy/vendor/domain.te
@@ -1,0 +1,1 @@
+allow { domain - isolated_app } sysfs_kgsl:lnk_file read;

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -11,6 +11,7 @@
 /data/vendor/syna(/.*)?                       u:object_r:fingerprint_data_file:s0
 /data/vendor/mac_addr(/.*)?                   u:object_r:wifi_vendor_data_file:s0
 /data/vendor/thermal(/.*)?                    u:object_r:thermal_data_file:s0
+/mnt/vendor/persist/goodix(/.*)?              u:object_r:fingerprint_data_file:s0
 
 # Executables
 /vendor/bin/mlipayd@1\.1                      u:object_r:hal_mlipay_default_exec:s0

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -14,6 +14,7 @@
 /mnt/vendor/persist/goodix(/.*)?              u:object_r:fingerprint_data_file:s0
 
 # Executables
+/vendor/bin/init.panel_info.sh                u:object_r:qti_init_shell_exec:s0
 /vendor/bin/mlipayd@1\.1                      u:object_r:hal_mlipay_default_exec:s0
 /vendor/bin/nv_mac                            u:object_r:wcnss_service_exec:s0
 

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -30,6 +30,7 @@
 /sys/devices/platform/soc/[0-9]+\.spi/spi_master/spi[0-9]+/spi[0-9]+\.0/nstandby   u:object_r:sysfs_gps:s0
 
 # Graphics nodes
+/sys/class/kgsl(/.*)?                         u:object_r:sysfs_kgsl:s0
 /sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/disp_param        u:object_r:sysfs_graphics:s0
 /sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/hbm_status        u:object_r:sysfs_graphics:s0
 /sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/panel_info        u:object_r:sysfs_graphics:s0

--- a/sepolicy/vendor/genfs_contexts
+++ b/sepolicy/vendor/genfs_contexts
@@ -9,6 +9,7 @@ genfscon sysfs /devices/platform/soc/5c00000.qcom,ssc/subsys5/restart_level    u
 genfscon sysfs /devices/platform/soc/8300000.qcom,turing/subsys6/restart_level u:object_r:sysfs_ssr_toggle:s0
 genfscon sysfs /devices/platform/soc/a88000.i2c/i2c-0/0-0061/power_supply/idt  u:object_r:sysfs_wireless_supply:s0
 genfscon sysfs /devices/platform/soc/aae0000.qcom,venus/subsys1/restart_level  u:object_r:sysfs_ssr_toggle:s0
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-00/c440000.qcom,spmi:qcom,pm660@0:qcom,pm660_rtc/rtc/rtc0/hctosys    u:object_r:sysfs_rtc:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-02/c440000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/wireless    u:object_r:sysfs_wireless_supply:s0
 genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-03/c440000.qcom,spmi:qcom,pm660l@3:qcom,leds@d000/leds/white    u:object_r:sysfs_graphics:s0
 genfscon sysfs /devices/platform/soc/soc:fingerprint_fpc/device_prepare        u:object_r:sysfs_fingerprint:s0

--- a/sepolicy/vendor/genfs_contexts
+++ b/sepolicy/vendor/genfs_contexts
@@ -1,6 +1,7 @@
 genfscon proc /tp_fw_version       u:object_r:proc_tp:s0
 genfscon proc /tp_lockdown_info    u:object_r:proc_tp:s0
 
+genfscon sysfs /devices/platform/cam_sync/video4linux/video1/name              u:object_r:sysfs_graphics:s0
 genfscon sysfs /devices/platform/soc/17300000.qcom,lpass/subsys4/restart_level u:object_r:sysfs_ssr_toggle:s0
 genfscon sysfs /devices/platform/soc/188101c.qcom,spss/subsys0/restart_level   u:object_r:sysfs_ssr_toggle:s0
 genfscon sysfs /devices/platform/soc/4080000.qcom,mss/subsys7/restart_level    u:object_r:sysfs_ssr_toggle:s0
@@ -15,6 +16,7 @@ genfscon sysfs /devices/platform/soc/soc:fingerprint_fpc/fingerdown_wait       u
 genfscon sysfs /devices/platform/soc/soc:fingerprint_fpc/irq                   u:object_r:sysfs_fingerprint:s0
 genfscon sysfs /devices/platform/soc/soc:fingerprint_fpc/wakeup_enable         u:object_r:sysfs_fingerprint:s0
 genfscon sysfs /devices/platform/soc/soc:fingerprint_goodix/proximity_state    u:object_r:sysfs_fingerprint:s0
+genfscon sysfs /devices/platform/soc/soc:qcom,cam-req-mgr/video4linux/video0/name    u:object_r:sysfs_graphics:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,dsi-display-primary/fod_hbm      u:object_r:sysfs_fod:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws/subsys2/restart_level    u:object_r:sysfs_ssr_toggle:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,kgsl-hyp/subsys3/restart_level   u:object_r:sysfs_ssr_toggle:s0

--- a/sepolicy/vendor/hal_camera_default.te
+++ b/sepolicy/vendor/hal_camera_default.te
@@ -16,3 +16,5 @@ get_prop(hal_camera_default, camera_ro_prop)
 userdebug_or_eng(`
   get_prop(hal_camera_default, sensors_dbg_prop)
 ')
+
+dontaudit hal_camera_default property_type:file { getattr open };

--- a/sepolicy/vendor/hal_fingerprint_default.te
+++ b/sepolicy/vendor/hal_fingerprint_default.te
@@ -3,6 +3,7 @@ allow hal_fingerprint_default fingerprint_data_file:dir create_dir_perms;
 allow hal_fingerprint_default fingerprint_data_file:file create_file_perms;
 allow hal_fingerprint_default self:netlink_socket create_socket_perms_no_ioctl;
 allow hal_fingerprint_default sysfs_fingerprint:file rw_file_perms;
+allow hal_fingerprint_default sysfs_graphics:file rw_file_perms;
 allow hal_fingerprint_default tee_device:chr_file rw_file_perms;
 allow hal_fingerprint_default uhid_device:chr_file rw_file_perms;
 allow hal_fingerprint_default input_device:dir r_dir_perms;

--- a/sepolicy/vendor/hal_fingerprint_default.te
+++ b/sepolicy/vendor/hal_fingerprint_default.te
@@ -9,6 +9,7 @@ allow hal_fingerprint_default input_device:dir r_dir_perms;
 allow hal_fingerprint_default input_device:chr_file rw_file_perms;
 allow hal_fingerprint_default qdsp_device:chr_file rw_file_perms;
 
+get_prop(hal_fingerprint_default, adsprpc_prop)
 set_prop(hal_fingerprint_default, vendor_fp_prop)
 hal_client_domain(hal_fingerprint_default, hal_perf)
 

--- a/sepolicy/vendor/hal_fingerprint_default.te
+++ b/sepolicy/vendor/hal_fingerprint_default.te
@@ -7,6 +7,7 @@ allow hal_fingerprint_default tee_device:chr_file rw_file_perms;
 allow hal_fingerprint_default uhid_device:chr_file rw_file_perms;
 allow hal_fingerprint_default input_device:dir r_dir_perms;
 allow hal_fingerprint_default input_device:chr_file rw_file_perms;
+allow hal_fingerprint_default qdsp_device:chr_file rw_file_perms;
 
 set_prop(hal_fingerprint_default, vendor_fp_prop)
 hal_client_domain(hal_fingerprint_default, hal_perf)

--- a/sepolicy/vendor/hal_lineage_fod_sdm710.te
+++ b/sepolicy/vendor/hal_lineage_fod_sdm710.te
@@ -10,4 +10,6 @@ allow hal_lineage_fod_sdm710 sysfs_graphics:file rw_file_perms;
 
 binder_call(hal_lineage_fod_sdm710, hal_fingerprint_default)
 
+get_prop(hal_lineage_fod_sdm710, vendor_fp_prop)
+
 hal_client_domain(hal_lineage_fod_sdm710, hal_fingerprint)

--- a/sepolicy/vendor/hal_wifi_default.te
+++ b/sepolicy/vendor/hal_wifi_default.te
@@ -1,0 +1,2 @@
+# Allow to set driver/fw version into property
+set_prop(hal_wifi_default, vendor_wifi_version)

--- a/sepolicy/vendor/init.te
+++ b/sepolicy/vendor/init.te
@@ -1,1 +1,3 @@
+allow init socket_device:sock_file { unlink setattr create };
+
 dontaudit init { bt_firmware_file firmware_file }:filesystem getattr;

--- a/sepolicy/vendor/init_shell.te
+++ b/sepolicy/vendor/init_shell.te
@@ -1,0 +1,8 @@
+# Allow UVC configuration from init.qcom.usb.sh
+allow qti_init_shell configfs:dir { add_name create write };
+allow qti_init_shell configfs:file create;
+allow qti_init_shell configfs:lnk_file create;
+
+# Allow chown /sys/class/leds/*/secure_mode
+allow qti_init_shell sysfs:file setattr;
+allow qti_init_shell sysfs_leds:file setattr;

--- a/sepolicy/vendor/init_shell.te
+++ b/sepolicy/vendor/init_shell.te
@@ -6,3 +6,6 @@ allow qti_init_shell configfs:lnk_file create;
 # Allow chown /sys/class/leds/*/secure_mode
 allow qti_init_shell sysfs:file setattr;
 allow qti_init_shell sysfs_leds:file setattr;
+
+# Allow to set fingerprint properties from init.panel_info.sh
+allow qti_init_shell vendor_fp_prop:property_service set;

--- a/sepolicy/vendor/poweroffalarm_app.te
+++ b/sepolicy/vendor/poweroffalarm_app.te
@@ -1,0 +1,2 @@
+# Settings app writes to /dev/stune/foreground/tasks.
+allow poweroffalarm_app cgroup:file w_file_perms;

--- a/sepolicy/vendor/property.te
+++ b/sepolicy/vendor/property.te
@@ -5,3 +5,5 @@ type thermal_engine_prop, property_type;
 type vendor_dpps_prop, property_type;
 
 type vendor_fp_prop, property_type;
+
+type vendor_wifi_version, property_type;

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -2,6 +2,7 @@
 camera.                     u:object_r:camera_prop:s0
 persist.camera.             u:object_r:camera_prop:s0
 persist.vendor.camera.      u:object_r:camera_prop:s0
+vendor.camera.              u:object_r:camera_prop:s0
 vidhance.                   u:object_r:camera_prop:s0
 
 # Display post processing

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -41,3 +41,7 @@ persist.sensor.sardisable  u:object_r:sensors_prop:s0
 
 # Thermal
 persist.sys.thermal.       u:object_r:thermal_engine_prop:s0
+
+# WiFi
+vendor.wlan.driver.version      u:object_r:vendor_wifi_version:s0
+vendor.wlan.firmware.version    u:object_r:vendor_wifi_version:s0

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -33,6 +33,9 @@ ro.miui.cust_variant       u:object_r:exported_default_prop:s0
 # Mlipay
 persist.vendor.sys.pay.ifaa              u:object_r:vendor_tee_listener_prop:s0
 
+# Recovery
+ro.build.expect.           u:object_r:exported_default_prop:s0
+
 # Sensors
 persist.sensor.sardisable  u:object_r:sensors_prop:s0
 

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -42,6 +42,7 @@ persist.sensor.sardisable  u:object_r:sensors_prop:s0
 
 # Thermal
 persist.sys.thermal.       u:object_r:thermal_engine_prop:s0
+sys.thermal.               u:object_r:thermal_engine_prop:s0
 
 # WiFi
 vendor.wlan.driver.version      u:object_r:vendor_wifi_version:s0

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -18,6 +18,7 @@ gf.debug.dump_bigdata_data u:object_r:vendor_fp_prop:s0
 persist.sys.fp.goodix.     u:object_r:vendor_fp_prop:s0
 persist.vendor.sys.fp.     u:object_r:vendor_fp_prop:s0
 ro.hardware.fp             u:object_r:vendor_fp_prop:s0
+sys.panel.                 u:object_r:vendor_fp_prop:s0
 vendor.fps_hal.            u:object_r:vendor_fp_prop:s0
 
 # Google camera hal read only props

--- a/sepolicy/vendor/radio.te
+++ b/sepolicy/vendor/radio.te
@@ -1,0 +1,3 @@
+# Allow radio to read audio property
+# "vendor.audio.voice.receiver.status"
+get_prop(radio, vendor_audio_prop)

--- a/sepolicy/vendor/thermal-engine.te
+++ b/sepolicy/vendor/thermal-engine.te
@@ -4,7 +4,9 @@ allow thermal-engine thermal_data_file:file create_file_perms;
 allow thermal-engine self:capability { chown fowner };
 allow thermal-engine sysfs_devfreq:dir r_dir_perms;
 
+# to read /sys/devices
+allow thermal-engine sysfs:dir r_dir_perms;
+
 set_prop(thermal-engine, thermal_engine_prop)
 
-dontaudit thermal-engine sysfs:dir read;
 dontaudit thermal-engine self:capability dac_override;

--- a/sepolicy/vendor/ueventd.te
+++ b/sepolicy/vendor/ueventd.te
@@ -1,0 +1,1 @@
+allow ueventd self:capability sys_nice;

--- a/sepolicy/vendor/vendor_init.te
+++ b/sepolicy/vendor/vendor_init.te
@@ -13,7 +13,7 @@ allow vendor_init persist_debug_prop:file read;
 allow vendor_init sysfs_ssr_toggle:file w_file_perms;
 
 # /data/tombstones stuff in init.qcom.rc
-allow vendor_init tombstone_data_file:dir { ioctl open read search setattr };
+allow vendor_init tombstone_data_file:dir create_dir_perms;
 allow vendor_init tombstone_data_file:lnk_file read;
 
 # Allow to set fingerprint properties

--- a/sepolicy/vendor/vendor_init.te
+++ b/sepolicy/vendor/vendor_init.te
@@ -1,2 +1,20 @@
+typeattribute vendor_init data_between_core_and_vendor_violators;
+
+# Allow to setattr to /dev/block/bootdevice/by-name/rawdump
+allow vendor_init block_device:lnk_file setattr;
+
+# Allow to set ro.vendor.gpu.available_frequencies
+allow vendor_init freq_prop:property_service set;
+
+# Allow to read persist.debug.trace
+allow vendor_init persist_debug_prop:file read;
+
 # Allow vendor_init to write to sysfs_ssr_toggle
 allow vendor_init sysfs_ssr_toggle:file w_file_perms;
+
+# /data/tombstones stuff in init.qcom.rc
+allow vendor_init tombstone_data_file:dir { ioctl open read search setattr };
+allow vendor_init tombstone_data_file:lnk_file read;
+
+# Allow to set fingerprint properties
+allow vendor_init vendor_fp_prop:property_service set;


### PR DESCRIPTION
The series fixes SELinux denials found during enforcing SELinux enablement on Pyxis. Most of commits are self-explanatory and contain sample of denial message.