### PR TITLE
Minor gps fixes

### DIFF
--- a/gps/android/2.0/android.hardware.gnss@2.0-service-qti.rc
+++ b/gps/android/2.0/android.hardware.gnss@2.0-service-qti.rc
@@ -1,4 +1,4 @@
 service gnss_service /vendor/bin/hw/android.hardware.gnss@2.0-service-qti
     class hal
     user gps
-    group system gps radio
+    group system gps radio vendor_qti_diag

--- a/gps/android/2.0/android.hardware.gnss@2.0-service-qti.xml
+++ b/gps/android/2.0/android.hardware.gnss@2.0-service-qti.xml
@@ -29,6 +29,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <hal format="hidl">
         <name>android.hardware.gnss</name>
         <transport>hwbinder</transport>
+        <fqname>@1.0::IGnss/gnss_vendor</fqname>
         <fqname>@1.1::IGnss/default</fqname>
         <fqname>@2.0::IGnss/default</fqname>
     </hal>

--- a/gps/android/2.0/service.cpp
+++ b/gps/android/2.0/service.cpp
@@ -73,6 +73,11 @@ int main() {
     #else
             ALOGE("LOC_HIDL_VERSION not defined.");
     #endif
+        } else {
+            status = registerPassthroughServiceImplementation<IGnss>("gnss_vendor");
+            if (status != OK) {
+                ALOGE("Error while registering gnss_vendor service: %d", status);
+            }
         }
 
         joinRpcThreadpool();


### PR DESCRIPTION
2  minor gps bugfixes from CAF upstream. The later allows us to remove android.hardware.gnss HAL entry from manifest.xml.