### PR TITLE
sdm710-common: Build libsuspend from source

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -523,7 +523,6 @@ vendor/lib64/vendor.qti.hardware.alarm@1.0.so
 
 # Power-off charging daemon
 system/bin/charger:system/bin/chargeonlymode
-system/lib64/libsuspend.so
 
 # QMI
 system/etc/permissions/qti_libpermissions.xml:system_ext/etc/permissions/qti_libpermissions.xml

--- a/sdm710.mk
+++ b/sdm710.mk
@@ -196,6 +196,9 @@ PRODUCT_PACKAGES += \
     android.hardware.health@2.1-impl.recovery \
     android.hardware.health@2.1-service
 
+PRODUCT_PACKAGES += \
+    libsuspend
+
 # HIDL
 PRODUCT_PACKAGES += \
     android.hidl.base@1.0 \


### PR DESCRIPTION
Resolves these duplicate rules:

  build/make/core/Makefile:49: warning: overriding commands for target
  `out/target/product/sirius/system/lib64/libsuspend.so'

  build/make/core/base_rules.mk:513: warning: ignoring old commands for target
  `out/target/product/sirius/system/lib64/libsuspend.so'

Signed-off-by: Alex Damaratski <alexeydomoratsky1@gmail.com>
Change-Id: Ia0e7ee7355c7cff5fabc296abecdf3c0f909fc60