### PR TITLE
Commonize ZRAM swap and fix ZRAM writeback

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -312,4 +312,7 @@
     <string-array name="config_biometric_sensors" translatable="false" >
         <item>0:2:15</item> <!-- ID0:Fingerprint:Strong -->
     </string-array>
+
+    <!-- Enable Zram writeback feature to allow unused pages in zram be written to flash. -->
+    <bool name="config_zramWriteback">true</bool>
 </resources>

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -209,10 +209,6 @@ on enable-low-power
     write /sys/devices/platform/soc/${ro.boot.bootdevice}/clkgate_enable 1
     write /sys/devices/platform/soc/${ro.boot.bootdevice}/hibern8_on_idle_enable 1
 
-    write /sys/module/vmpressure/parameters/allocstall_threshold 0
-    write /proc/sys/vm/swappiness 100
-    write /proc/sys/vm/watermark_scale_factor 1
-
     # Post-setup services
     setprop vendor.post_boot.parsed 1
 

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -43,9 +43,17 @@ on early-init
     chmod 0620 /dev/kmsg
 
 on init
-    # ZRAM setup
+    ## Swap parameters
+    # Set compression algorithm for ZRAM to LZ4
     write /sys/block/zram0/comp_algorithm lz4
+    # Disable swap read-ahead
     write /proc/sys/vm/page-cluster 0
+    # Set aggressive swapping
+    write /proc/sys/vm/swappiness 100
+    # Set kswapd agressiveness to minimum
+    write /proc/sys/vm/watermark_scale_factor 1
+    # Set allocstall_threshold to 0
+    write /sys/module/vmpressure/parameters/allocstall_threshold 0
 
 on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -42,26 +42,12 @@ on early-init
     chown root system /dev/kmsg
     chmod 0620 /dev/kmsg
 
-on init
-    ## Swap parameters
-    # Set compression algorithm for ZRAM to LZ4
-    write /sys/block/zram0/comp_algorithm lz4
-    # Disable swap read-ahead
-    write /proc/sys/vm/page-cluster 0
-    # Set aggressive swapping
-    write /proc/sys/vm/swappiness 100
-    # Set kswapd agressiveness to minimum
-    write /proc/sys/vm/watermark_scale_factor 1
-    # Set allocstall_threshold to 0
-    write /sys/module/vmpressure/parameters/allocstall_threshold 0
-
 on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
     mkdir /mnt/vendor/persist 0771 root system
     mount_all /vendor/etc/fstab.qcom
     chmod 0771 /mnt/vendor/persist
-    swapon_all /vendor/etc/fstab.qcom
     restorecon_recursive /mnt/vendor/persist
     mkdir /mnt/vendor/persist/audio 0755 system system
     mkdir /mnt/vendor/persist/data 0700 system system
@@ -419,6 +405,20 @@ on property:sys.boot_completed=1
     chown media audio /sys/kernel/wcd_cpe0/fw_name
     #Reinit lmkd to reconfigure lmkd properties
     setprop lmkd.reinit 1
+
+    ## Set swap parameters and enable swapping
+    # Set compression algorithm for ZRAM to LZ4
+    write /sys/block/zram0/comp_algorithm lz4
+    # Disable swap read-ahead
+    write /proc/sys/vm/page-cluster 0
+    # Set aggressive swapping
+    write /proc/sys/vm/swappiness 100
+    # Set kswapd agressiveness to minimum
+    write /proc/sys/vm/watermark_scale_factor 1
+    # Set allocstall_threshold to 0
+    write /sys/module/vmpressure/parameters/allocstall_threshold 0
+    # Enable swap
+    swapon_all /vendor/etc/fstab.qcom
 
     start qcom-post-boot
 

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -43,13 +43,6 @@ on early-init
     chmod 0620 /dev/kmsg
 
 on init
-    # Create cgroup mount point for memory
-    mkdir /sys/fs/cgroup/memory/bg 0750 root system
-    write /sys/fs/cgroup/memory/bg/memory.swappiness 140
-    write /sys/fs/cgroup/memory/bg/memory.move_charge_at_immigrate 1
-    chown root system /sys/fs/cgroup/memory/bg/tasks
-    chmod 0660 /sys/fs/cgroup/memory/bg/tasks
-
     # ZRAM setup
     write /sys/block/zram0/comp_algorithm lz4
     write /proc/sys/vm/page-cluster 0

--- a/system.prop
+++ b/system.prop
@@ -83,5 +83,10 @@ ro.com.android.dataroaming=true
 ro.telephony.default_network=10,10
 telephony.lteOnCdmaDevice=1
 
+# ZRAM writeback
+ro.zram.first_wb_delay_mins=180
+ro.zram.mark_idle_delay_mins=60
+ro.zram.periodic_wb_delay_hours=24
+
 # Zygote
 persist.device_config.runtime_native.usap_pool_enabled=true


### PR DESCRIPTION
The series ...

- removes memory cgroups settings as we have now disabled them in kernel
- enables zram write-back scheduler for all devices
- move zram settings, swap parameters and swap enablement to single place
- fixes zram writeback due to misplaced swapon_all

Verified on pyxis.