### PR TITLE
sdm710-common: add missing persist.vendor.dpmhalservice.enable property

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -374,6 +374,9 @@ on post-fs-data
     # Make MTU adjusting
     write /proc/sys/net/ipv4/tcp_mtu_probing 1
 
+    # Init sensors
+    start vendor-sensor-sh
+
 on property:ro.vendor.iocgrp.config=1
     mkdir /dev/blkio
     mount cgroup none /dev/blkio blkio
@@ -561,9 +564,6 @@ service vendor.power /vendor/bin/hw/android.hardware.power-service-qti
     class hal
     user system
     group system input
-
-on property:vold.decrypt=trigger_restart_framework
-    start vendor-sensor-sh
 
 on boot && property:persist.vendor.usb.controller.default=*
     setprop vendor.usb.controller ${persist.vendor.usb.controller.default}

--- a/vendor.prop
+++ b/vendor.prop
@@ -107,6 +107,9 @@ persist.vendor.cne.feature=1
 # Display post-processing
 ro.vendor.display.cabl=2
 
+# DPM
+persist.vendor.dpmhalservice.enable=1
+
 # DRM
 drm.service.enabled=true
 


### PR DESCRIPTION
Service dpmQmiMgr is started by trigger when property
persist.vendor.dpmhalservice.enable is set.

Change-Id: I50b84979b1b46e88ba5faddad27dfc3658cafc75
Signed-off-by: Ivan Vecera <ivan@cera.cz>