### PR TITLE
Re-implement Dirac using MiSoundFX

### DIFF
--- a/audio/audio_effects.xml
+++ b/audio/audio_effects.xml
@@ -41,7 +41,6 @@
         <library name="volume_listener" path="libvolumelistener.so"/>
         <library name="audiosphere" path="libasphere.so"/>
         <library name="shoebox" path="libshoebox.so"/>
-        <library name="dirac" path="libdirac.so"/>
         <library name="misoundfx" path="libmisoundfx.so"/>
     </libraries>
     <effects>
@@ -90,7 +89,6 @@
         <effect name="notification_helper" library="volume_listener" uuid="0b776dde-0590-11e5-81ba-0025b32654a0"/>
         <effect name="audiosphere" library="audiosphere" uuid="184e62ab-2d19-4364-9d1b-c0a40733866c"/>
         <effect name="shoebox" library="shoebox" uuid="1eab784c-1a36-4b2a-b7fc-e34c44cab89e"/>
-        <effect name="dirac" library="dirac" uuid="e069d9e0-8329-11df-9168-0002a5d5c51b"/>
         <effect name="misoundfx" library="misoundfx" uuid="5b8e36a5-144a-4c38-b1d7-0002a5d5c51b"/>
     </effects>
     <postprocess>

--- a/audio/audio_effects.xml
+++ b/audio/audio_effects.xml
@@ -42,6 +42,7 @@
         <library name="audiosphere" path="libasphere.so"/>
         <library name="shoebox" path="libshoebox.so"/>
         <library name="dirac" path="libdirac.so"/>
+        <library name="misoundfx" path="libmisoundfx.so"/>
     </libraries>
     <effects>
         <effectProxy name="bassboost" library="proxy" uuid="14804144-a5ee-4d24-aa88-0002a5d5c51b">
@@ -90,6 +91,7 @@
         <effect name="audiosphere" library="audiosphere" uuid="184e62ab-2d19-4364-9d1b-c0a40733866c"/>
         <effect name="shoebox" library="shoebox" uuid="1eab784c-1a36-4b2a-b7fc-e34c44cab89e"/>
         <effect name="dirac" library="dirac" uuid="e069d9e0-8329-11df-9168-0002a5d5c51b"/>
+        <effect name="misoundfx" library="misoundfx" uuid="5b8e36a5-144a-4c38-b1d7-0002a5d5c51b"/>
     </effects>
     <postprocess>
         <stream type="music">

--- a/parts/res/values-ar/strings.xml
+++ b/parts/res/values-ar/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">إيقاع</string>
+    <string name="dirac_preset_classical">كلاسيك</string>
+    <string name="dirac_preset_country">الريف</string>
+    <string name="dirac_preset_dance">رقص</string>
+    <string name="dirac_preset_electronic">الكتروني</string>
+    <string name="dirac_default">الافتراضي</string>
+    <string name="dirac_preset_jazz">جاز</string>
+    <string name="dirac_preset_metal">معدن</string>
+    <string name="dirac_preset_pop">بوب</string>
+    <string name="dirac_preset_rock">روك</string>
+    <string name="dirac_headset_cancelling">إلغاء الضوضاء Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">عام</string>
+    <string name="dirac_headset_general_inear">عامة In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">سماعات رأس Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">(Mi In-Ear (2013</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">إصدار رئيسي</string>
+    <string name="dirac_headset_piston_color">إصدار اللون</string>
+    <string name="dirac_headset_piston_standard">إصدار قياسي</string>
+    <string name="dirac_headset_piston_youth">إصدار شبابي</string>
+    <string name="dirac_headset_reduction_noise">إلغاء الضوضاء Mi Type-C</string>
+    <string name="dirac_headset_title">اختيار نوع سماعة الرأس</string>
+    <string name="dirac_title">محسن صوت Mi</string>
+    <string name="dirac_preset_title">إعداد</string>
+</resources>

--- a/parts/res/values-as-rIN/strings.xml
+++ b/parts/res/values-as-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ব্লুজ</string>
+    <string name="dirac_preset_classical">ক্লাছিকেল</string>
+    <string name="dirac_preset_country">কাণ্ট্ৰি</string>
+    <string name="dirac_preset_dance">নৃত্য</string>
+    <string name="dirac_preset_electronic">ইলেকট্ৰনিক</string>
+    <string name="dirac_default">"ডিফ'ল্ট"</string>
+    <string name="dirac_preset_jazz">জাজ</string>
+    <string name="dirac_preset_metal">মেটেল</string>
+    <string name="dirac_preset_pop">পপ</string>
+    <string name="dirac_preset_rock">ৰক</string>
+    <string name="dirac_headset_cancelling">Mi কোলাহল বাতিলকৰণ 3.5মি.মি.</string>
+    <string name="dirac_headset_capsule">Mi কেপচুল</string>
+    <string name="dirac_headset_earbuds">Mi ইয়েৰবাড</string>
+    <string name="dirac_headset_general">সাধাৰণ</string>
+    <string name="dirac_headset_general_inear">সাধাৰণ ইন-ইয়েৰ</string>
+    <string name="dirac_headset_half_in_ear">Mi হাফ ইন ইয়েৰ</string>
+    <string name="dirac_headset_headphone">Mi হেডফোন</string>
+    <string name="dirac_headset_comfort">Mi আৰাম</string>
+    <string name="dirac_headset_in_ear">Mi ইন-ইয়েৰ</string>
+    <string name="dirac_headset_in_ear2">Mi ইন-ইয়েৰ 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ইন-ইয়েৰ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">"Mi ইন-ইয়েৰ প্ৰ'"</string>
+    <string name="dirac_headset_piston_1">Mi পিষ্টন-1</string>
+    <string name="dirac_headset_piston_2">Mi পিষ্টন-2</string>
+    <string name="dirac_headset_piston_basic">প্ৰাথমিক সংস্কৰণ</string>
+    <string name="dirac_headset_piston_color">ৰঙীণ সংস্কৰণ</string>
+    <string name="dirac_headset_piston_standard">মান্য সংস্কৰণ</string>
+    <string name="dirac_headset_piston_youth">যুৱ সংস্কৰণ</string>
+    <string name="dirac_headset_reduction_noise">Mi কোলাহল বাতিলকৰণ টাইপ-C</string>
+    <string name="dirac_headset_title">হেডফোনৰ প্ৰকাৰ পচন্দ কৰক</string>
+    <string name="dirac_title">Mi ধ্বনি পৰিবৰ্ধক</string>
+    <string name="dirac_preset_title">পুৰ্বছেট</string>
+</resources>

--- a/parts/res/values-az-rAZ/strings.xml
+++ b/parts/res/values-az-rAZ/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blyuz</string>
+    <string name="dirac_preset_classical">Klassik</string>
+    <string name="dirac_preset_country">Kantri</string>
+    <string name="dirac_preset_dance">Rəqs</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Varsayılan</string>
+    <string name="dirac_preset_jazz">Caz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rok</string>
+    <string name="dirac_headset_cancelling">Mi Səs-küy Əngəlləmə 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Kapsul</string>
+    <string name="dirac_headset_earbuds">Mi Qulaqlıqları</string>
+    <string name="dirac_headset_general">Ümumi</string>
+    <string name="dirac_headset_general_inear">Ümumi Qulaq-İçi</string>
+    <string name="dirac_headset_half_in_ear">Mi Yarı Qulaq-içi</string>
+    <string name="dirac_headset_headphone">Mi Qulaqlıqları</string>
+    <string name="dirac_headset_comfort">Mi Rahatlıq</string>
+    <string name="dirac_headset_in_ear">Mi Qulaq-İçi</string>
+    <string name="dirac_headset_in_ear2">Mi Qulaq-İçi 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi Qulaq-İçi (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi Qulaq-İçi Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Sadə versiya</string>
+    <string name="dirac_headset_piston_color">Rəngli versiyası</string>
+    <string name="dirac_headset_piston_standard">Standart versiya</string>
+    <string name="dirac_headset_piston_youth">Gənc versiyası</string>
+    <string name="dirac_headset_reduction_noise">Mi Səs-küy Əngəlləmə Type-C</string>
+    <string name="dirac_headset_title">Qulaqlıq növünü seçin</string>
+    <string name="dirac_title">Mi Səs Gücləndirici</string>
+    <string name="dirac_preset_title">Ön tənzimləmə</string>
+</resources>

--- a/parts/res/values-be/strings.xml
+++ b/parts/res/values-be/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блюз</string>
+    <string name="dirac_preset_classical">Класіка</string>
+    <string name="dirac_preset_country">Кантры</string>
+    <string name="dirac_preset_dance">Танцавальная</string>
+    <string name="dirac_preset_electronic">Электра</string>
+    <string name="dirac_default">Па змаўчанні</string>
+    <string name="dirac_preset_jazz">Джаз</string>
+    <string name="dirac_preset_metal">Метал</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi Шумападаўленне 3,5 мм</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi-навушнікі</string>
+    <string name="dirac_headset_general">Звычайныя навушнікі</string>
+    <string name="dirac_headset_general_inear">Звычайныя ўкладышы</string>
+    <string name="dirac_headset_half_in_ear">Mi-укладышы</string>
+    <string name="dirac_headset_headphone">Mi навушнікі</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi-укладышы</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi-пістоны 1</string>
+    <string name="dirac_headset_piston_2">Mi-пістоны 2</string>
+    <string name="dirac_headset_piston_basic">Звыч. пістоны</string>
+    <string name="dirac_headset_piston_color">Каляровае версія</string>
+    <string name="dirac_headset_piston_standard">Стандартная версія</string>
+    <string name="dirac_headset_piston_youth">Моладзевая версія</string>
+    <string name="dirac_headset_reduction_noise">Mi Шумападаўленне Type-C</string>
+    <string name="dirac_headset_title">Выберыце тып навушнікаў</string>
+    <string name="dirac_title">Паляпшэнне гуку Mi</string>
+    <string name="dirac_preset_title">Прасэт</string>
+</resources>

--- a/parts/res/values-bg/strings.xml
+++ b/parts/res/values-bg/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блус</string>
+    <string name="dirac_preset_classical">Класика</string>
+    <string name="dirac_preset_country">Кънтри</string>
+    <string name="dirac_preset_dance">Танцувална</string>
+    <string name="dirac_preset_electronic">Електронна</string>
+    <string name="dirac_default">По подразбиране</string>
+    <string name="dirac_preset_jazz">Джаз</string>
+    <string name="dirac_preset_metal">Метъл</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi шумопотискане 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi капсула</string>
+    <string name="dirac_headset_earbuds">Mi слушалки</string>
+    <string name="dirac_headset_general">Обикновени</string>
+    <string name="dirac_headset_general_inear">Обикновени \"тапи за уши\"</string>
+    <string name="dirac_headset_half_in_ear">Вградени слушалки Mi</string>
+    <string name="dirac_headset_headphone">Mi Слушалки</string>
+    <string name="dirac_headset_comfort">Mi Комфорт</string>
+    <string name="dirac_headset_in_ear">Mi in-ear headphones</string>
+    <string name="dirac_headset_in_ear2">Mi слушалки на две уши</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">Обикновени</string>
+    <string name="dirac_headset_piston_color">Цветно издание</string>
+    <string name="dirac_headset_piston_standard">Стандартна версия</string>
+    <string name="dirac_headset_piston_youth">Mi piston-youth</string>
+    <string name="dirac_headset_reduction_noise">Mi шумопотискане Тип-C</string>
+    <string name="dirac_headset_title">Вид слушалки</string>
+    <string name="dirac_title">Използване на MiSound enhancer</string>
+    <string name="dirac_preset_title">Настройка</string>
+</resources>

--- a/parts/res/values-bn-rBD/strings.xml
+++ b/parts/res/values-bn-rBD/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ব্লুজ</string>
+    <string name="dirac_preset_classical">ক্লাসিকাল</string>
+    <string name="dirac_preset_country">কান্ট্রি</string>
+    <string name="dirac_preset_dance">নাচ</string>
+    <string name="dirac_preset_electronic">ইলেক্ট্রনিক</string>
+    <string name="dirac_default">ডিফল্ট</string>
+    <string name="dirac_preset_jazz">জ্যাজ</string>
+    <string name="dirac_preset_metal">মেটাল</string>
+    <string name="dirac_preset_pop">পপ</string>
+    <string name="dirac_preset_rock">রক</string>
+    <string name="dirac_headset_cancelling">Mi কোলাহল বাতিল (3.5মি. মি.)</string>
+    <string name="dirac_headset_capsule">Mi ক্যাপসুল</string>
+    <string name="dirac_headset_earbuds">Mi ইয়ারবাড</string>
+    <string name="dirac_headset_general">সাধারণ</string>
+    <string name="dirac_headset_general_inear">সাধারণত কানে</string>
+    <string name="dirac_headset_half_in_ear">Mi হাফ ইন ইয়ার</string>
+    <string name="dirac_headset_headphone">Mi হেডফোন</string>
+    <string name="dirac_headset_comfort">Mi কমফর্ট</string>
+    <string name="dirac_headset_in_ear">Mi ইন-ইয়ার</string>
+    <string name="dirac_headset_in_ear2">Mi ইন-ইয়ার 2</string>
+    <string name="dirac_headset_in_ear_2013">"Mi  ইন- ইয়ার(2013)"</string>
+    <string name="dirac_headset_in_ear_pro">Mi ইন ইয়ার প্রো</string>
+    <string name="dirac_headset_piston_1">Mi পিসটন-১</string>
+    <string name="dirac_headset_piston_2">Mi পিসটন-২</string>
+    <string name="dirac_headset_piston_basic">বেসিক ভার্সন</string>
+    <string name="dirac_headset_piston_color">রঙ সম্পাদক</string>
+    <string name="dirac_headset_piston_standard">" আদর্শ ভার্সন"</string>
+    <string name="dirac_headset_piston_youth">যুবা ভার্সন</string>
+    <string name="dirac_headset_reduction_noise">Mi কোলাহল বাতিল টাইপ-C</string>
+    <string name="dirac_headset_title">হেডফোনের প্রকার বেছে নিন</string>
+    <string name="dirac_title">Mi সাউন্ড বিবর্ধক</string>
+    <string name="dirac_preset_title">প্রিসেট</string>
+</resources>

--- a/parts/res/values-bn-rIN/strings.xml
+++ b/parts/res/values-bn-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ব্লুজ</string>
+    <string name="dirac_preset_classical">ক্লাসিকাল</string>
+    <string name="dirac_preset_country">কান্ট্রি</string>
+    <string name="dirac_preset_dance">নাচ</string>
+    <string name="dirac_preset_electronic">ইলেক্ট্রনিক</string>
+    <string name="dirac_default">ডিফল্ট</string>
+    <string name="dirac_preset_jazz">জ্যাজ</string>
+    <string name="dirac_preset_metal">মেটাল</string>
+    <string name="dirac_preset_pop">পপ</string>
+    <string name="dirac_preset_rock">রক</string>
+    <string name="dirac_headset_cancelling">Mi কোলাহল বাতিল (3.5মি. মি.)</string>
+    <string name="dirac_headset_capsule">Mi ক্যাপসুল</string>
+    <string name="dirac_headset_earbuds">Mi ইয়ারবাড</string>
+    <string name="dirac_headset_general">সাধারণ</string>
+    <string name="dirac_headset_general_inear">সাধারণত কানে</string>
+    <string name="dirac_headset_half_in_ear">Mi হাফ ইন ইয়ার</string>
+    <string name="dirac_headset_headphone">Mi হেডফোন</string>
+    <string name="dirac_headset_comfort">Mi কমফর্ট</string>
+    <string name="dirac_headset_in_ear">Mi ইন-ইয়ার</string>
+    <string name="dirac_headset_in_ear2">Mi ইন-ইয়ার 2</string>
+    <string name="dirac_headset_in_ear_2013">"Mi  ইন- ইয়ার(2013)"</string>
+    <string name="dirac_headset_in_ear_pro">Mi ইন ইয়ার প্রো</string>
+    <string name="dirac_headset_piston_1">Mi পিসটন-১</string>
+    <string name="dirac_headset_piston_2">Mi পিসটন-২</string>
+    <string name="dirac_headset_piston_basic">বেসিক ভার্সন</string>
+    <string name="dirac_headset_piston_color">রঙ সম্পাদক</string>
+    <string name="dirac_headset_piston_standard">" আদর্শ ভার্সন"</string>
+    <string name="dirac_headset_piston_youth">যুবা ভার্সন</string>
+    <string name="dirac_headset_reduction_noise">Mi কোলাহল বাতিল টাইপ-C</string>
+    <string name="dirac_headset_title">হেডফোনের প্রকার বেছে নিন</string>
+    <string name="dirac_title">Mi সাউন্ড বিবর্ধক</string>
+    <string name="dirac_preset_title">প্রিসেট</string>
+</resources>

--- a/parts/res/values-bo-rCN/strings.xml
+++ b/parts/res/values-bo-rCN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">blues</string>
+    <string name="dirac_preset_classical">གནའ་ཉམས།</string>
+    <string name="dirac_preset_country">གྲོང་གསེབ།</string>
+    <string name="dirac_preset_dance">གར་དབྱངས།</string>
+    <string name="dirac_preset_electronic">གློག་རྡུལ་རོལ་དབྱངས།</string>
+    <string name="dirac_default">མེད།</string>
+    <string name="dirac_preset_jazz">རྗེར་སི།</string>
+    <string name="dirac_preset_metal">ལྕགས་རིགས།</string>
+    <string name="dirac_preset_pop">དར་གསོ།</string>
+    <string name="dirac_preset_rock">ཡོམ་འགུལ།</string>
+    <string name="dirac_headset_cancelling">ཞའོ་མཱི་འཛེར་འགོག mm3.5</string>
+    <string name="dirac_headset_capsule">ཞོའི་མཱི་སྤྱིན་ཐུམ།</string>
+    <string name="dirac_headset_earbuds">"ཚོར་འགུལ་རྣར་རྫང་དཔེ་ཚུལ། "</string>
+    <string name="dirac_headset_general">རྒྱུན་སྤྱོད།</string>
+    <string name="dirac_headset_general_inear">"རྒྱུན་སྤྱོད་རྣར་གཞུག་དཔེ་ཚུལ། "</string>
+    <string name="dirac_headset_half_in_ear">ཞའོ་མྰི་རྣ་ཕྱེད་འཇུག་གྲས།</string>
+    <string name="dirac_headset_headphone">"ཞའོ་མཱི་མགོར་གོན་དཔེ་ཚུལ། "</string>
+    <string name="dirac_headset_comfort">ཞའོ་མཱི་མགོ་འདོགས་སྟབས་བདེའི་པར་གཞི།</string>
+    <string name="dirac_headset_in_ear">"ཞའོ་མཱི་ལྕགས་སྐོར། "</string>
+    <string name="dirac_headset_in_ear2">ཞའོ་མྰི་ལྕགས་སྐོར2</string>
+    <string name="dirac_headset_in_ear_2013">ཚོར་ཟིམ་རྣར་གཞུག་དཔེ་ཚུལ།</string>
+    <string name="dirac_headset_in_ear_pro">ཞའོ་མཱི་ལྕགས་སྐོར།Pro</string>
+    <string name="dirac_headset_piston_1">ཞའོ་མཱི་མེ་འབུགས1</string>
+    <string name="dirac_headset_piston_2">ཞའོ་མཱི་མེ་འབུགས2</string>
+    <string name="dirac_headset_piston_basic">"ཞའོ་མཱི་མེ་འབུགས་པར་གཞི་སླ་འཇུག་རིགས། "</string>
+    <string name="dirac_headset_piston_color">"ཞའོ་མཱི་མེ་འབུགས་པར་གཞི་མཚར་སྡུག་རིགས། "</string>
+    <string name="dirac_headset_piston_standard">"ཞའོ་མཱི་མེ་འབུགས་ཚད་ལྡན་པར་གཞི། "</string>
+    <string name="dirac_headset_piston_youth">"ཞའོ་མཱི་མེ་འབུགས་ལང་ཚོའི་པར་གཞི། "</string>
+    <string name="dirac_headset_reduction_noise">ཞའོ་མཱི་གཙེར་གཅོག typeC</string>
+    <string name="dirac_headset_title">"ཉན་ཆས་རིགས་སྒྲིག་འགོད། "</string>
+    <string name="dirac_title">མཱི་སྒྲ་བེད་སྤྱད་དེ་སྒྲ་གཤིས་མཐོར་འདེགས་བྱེད་པ།</string>
+    <string name="dirac_preset_title">རྣ་ཤེས།</string>
+</resources>

--- a/parts/res/values-bs/strings.xml
+++ b/parts/res/values-bs/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Bluz</string>
+    <string name="dirac_preset_classical">Klasična</string>
+    <string name="dirac_preset_country">Kantri</string>
+    <string name="dirac_preset_dance">Dens</string>
+    <string name="dirac_preset_electronic">Elektronska</string>
+    <string name="dirac_default">Podrazumijevano</string>
+    <string name="dirac_preset_jazz">Džez</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rok</string>
+    <string name="dirac_headset_cancelling">Mi Noise otkazivanje 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi kapsula</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Opšte</string>
+    <string name="dirac_headset_general_inear">Opšte In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi slušalice</string>
+    <string name="dirac_headset_comfort">Mi Komfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">Osnovno izdanje</string>
+    <string name="dirac_headset_piston_color">Izdanje u boji</string>
+    <string name="dirac_headset_piston_standard">Standardno izdanje</string>
+    <string name="dirac_headset_piston_youth">Izdanje za mlade</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise otkazivanje buke tip-C</string>
+    <string name="dirac_headset_title">Odaberite vrstu slušalica</string>
+    <string name="dirac_title">Mi Sound pojačivač</string>
+    <string name="dirac_preset_title">Postavke</string>
+</resources>

--- a/parts/res/values-ca/strings.xml
+++ b/parts/res/values-ca/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clàssica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electrònica</string>
+    <string name="dirac_default">Per defecte</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metall</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Cancel·la sorolls Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Càpsula</string>
+    <string name="dirac_headset_earbuds">Mi</string>
+    <string name="dirac_headset_general">Normal</string>
+    <string name="dirac_headset_general_inear">In-ear normals</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Auriculars</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi in-ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Edició Bàsica</string>
+    <string name="dirac_headset_piston_color">Edició de color</string>
+    <string name="dirac_headset_piston_standard">Edició Estàndard</string>
+    <string name="dirac_headset_piston_youth">Edició Jove</string>
+    <string name="dirac_headset_reduction_noise">Cancel·la sorolls Mi Tipus C</string>
+    <string name="dirac_headset_title">"Seleccioneu el tipus d'auriculars"</string>
+    <string name="dirac_title">Potenciador de so Mi</string>
+    <string name="dirac_preset_title">Preestablert</string>
+</resources>

--- a/parts/res/values-cs/strings.xml
+++ b/parts/res/values-cs/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasická</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Taneční</string>
+    <string name="dirac_preset_electronic">Elektronická</string>
+    <string name="dirac_default">Výchozí</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi kapsle</string>
+    <string name="dirac_headset_earbuds">Mi pecky</string>
+    <string name="dirac_headset_general">Obyčejná</string>
+    <string name="dirac_headset_general_inear">Běžné špunty</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi sluchátka</string>
+    <string name="dirac_headset_comfort">Mi Komfort</string>
+    <string name="dirac_headset_in_ear">Mi špunty</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi špunty (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi špunty Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston 1</string>
+    <string name="dirac_headset_piston_2">Mi Piston 2</string>
+    <string name="dirac_headset_piston_basic">Základní edice</string>
+    <string name="dirac_headset_piston_color">Barevná edice</string>
+    <string name="dirac_headset_piston_standard">Standardní edice</string>
+    <string name="dirac_headset_piston_youth">Pro mladé</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Typ sluchátek</string>
+    <string name="dirac_title">Vylepšení Mi Sound</string>
+    <string name="dirac_preset_title">Přednastavení</string>
+</resources>

--- a/parts/res/values-da/strings.xml
+++ b/parts/res/values-da/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassisk</string>
+    <string name="dirac_preset_country">Countrymusik</string>
+    <string name="dirac_preset_dance">Dans</string>
+    <string name="dirac_preset_electronic">Elektronisk</string>
+    <string name="dirac_default">Standard</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi-støjreduktion 3,5 mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi ørepropper</string>
+    <string name="dirac_headset_general">Generelt</string>
+    <string name="dirac_headset_general_inear">Generelt In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi hovedtelefoner</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi in-ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic Edition</string>
+    <string name="dirac_headset_piston_color">Color Edition</string>
+    <string name="dirac_headset_piston_standard">Standard Edition</string>
+    <string name="dirac_headset_piston_youth">Youth Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi-støjreduktion type C</string>
+    <string name="dirac_headset_title">Vælg type hovedtelefon</string>
+    <string name="dirac_title">Mi-lydforstærker</string>
+    <string name="dirac_preset_title">Faste indstillinger</string>
+</resources>

--- a/parts/res/values-de/strings.xml
+++ b/parts/res/values-de/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassisch</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Standard</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi-Geräuschunterdrückung (3.5 mm)</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Ohrhörer</string>
+    <string name="dirac_headset_general">Allgemeine Ohrhörer</string>
+    <string name="dirac_headset_general_inear">Allgemeine In Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In Ear</string>
+    <string name="dirac_headset_headphone">Mi Kopfhörer</string>
+    <string name="dirac_headset_comfort">Mi Komfort</string>
+    <string name="dirac_headset_in_ear">Mi In Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston 1</string>
+    <string name="dirac_headset_piston_2">Mi Piston 2</string>
+    <string name="dirac_headset_piston_basic">Basis Edition</string>
+    <string name="dirac_headset_piston_color">Farbige Edition</string>
+    <string name="dirac_headset_piston_standard">Standardedition</string>
+    <string name="dirac_headset_piston_youth">Jugend Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi-Geräuschunterdrückung (Typ-C)</string>
+    <string name="dirac_headset_title">Kopfhörertyp auswählen</string>
+    <string name="dirac_title">Mi Klangverbesserung</string>
+    <string name="dirac_preset_title">Voreinstellung</string>
+</resources>

--- a/parts/res/values-el/strings.xml
+++ b/parts/res/values-el/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Μπλουζ</string>
+    <string name="dirac_preset_classical">Κλασσική</string>
+    <string name="dirac_preset_country">Κάντρι</string>
+    <string name="dirac_preset_dance">Χορός</string>
+    <string name="dirac_preset_electronic">Ηλεκτρόνικ</string>
+    <string name="dirac_default">Προεπιλογή</string>
+    <string name="dirac_preset_jazz">Τζάζ</string>
+    <string name="dirac_preset_metal">Μέταλ</string>
+    <string name="dirac_preset_pop">Ποπ</string>
+    <string name="dirac_preset_rock">Ροκ</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Γενικά</string>
+    <string name="dirac_headset_general_inear">Γενικά In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic Edition</string>
+    <string name="dirac_headset_piston_color">Color Edition</string>
+    <string name="dirac_headset_piston_standard">Standard Edition</string>
+    <string name="dirac_headset_piston_youth">Youth Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Επιλογή τύπου ακουστικών</string>
+    <string name="dirac_title">Ενισχυτής Mi Ήχου</string>
+    <string name="dirac_preset_title">Προεπιλογές</string>
+</resources>

--- a/parts/res/values-en-rAU/strings.xml
+++ b/parts/res/values-en-rAU/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Classical</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electronic</string>
+    <string name="dirac_default">Default</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">General</string>
+    <string name="dirac_headset_general_inear">General In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic Edition</string>
+    <string name="dirac_headset_piston_color">Colour Edition</string>
+    <string name="dirac_headset_piston_standard">Standard Edition</string>
+    <string name="dirac_headset_piston_youth">Youth Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Choose headphones type</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Preset</string>
+</resources>

--- a/parts/res/values-en-rGB/strings.xml
+++ b/parts/res/values-en-rGB/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Classical</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electronic</string>
+    <string name="dirac_default">Default</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">General</string>
+    <string name="dirac_headset_general_inear">General In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic Edition</string>
+    <string name="dirac_headset_piston_color">Colour Edition</string>
+    <string name="dirac_headset_piston_standard">Standard Edition</string>
+    <string name="dirac_headset_piston_youth">Youth Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Choose headphones type</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Preset</string>
+</resources>

--- a/parts/res/values-en-rIN/strings.xml
+++ b/parts/res/values-en-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Classical</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electronic</string>
+    <string name="dirac_default">Default</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">General</string>
+    <string name="dirac_headset_general_inear">General In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic Edition</string>
+    <string name="dirac_headset_piston_color">Colour Edition</string>
+    <string name="dirac_headset_piston_standard">Standard Edition</string>
+    <string name="dirac_headset_piston_youth">Youth Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Choose headphones type</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Preset</string>
+</resources>

--- a/parts/res/values-es-rUS/strings.xml
+++ b/parts/res/values-es-rUS/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clásica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Baile</string>
+    <string name="dirac_preset_electronic">Electrónica</string>
+    <string name="dirac_default">Predeterminado</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5 mm</string>
+    <string name="dirac_headset_capsule">Mi Cápsula</string>
+    <string name="dirac_headset_earbuds">Mi Audífonos</string>
+    <string name="dirac_headset_general">Normales</string>
+    <string name="dirac_headset_general_inear">Normales In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Audífonos</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Audífonos intrauriculares Mi 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Edición Básica</string>
+    <string name="dirac_headset_piston_color">Edición Color</string>
+    <string name="dirac_headset_piston_standard">Edición Estándar</string>
+    <string name="dirac_headset_piston_youth">Edición Joven</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Tipo C</string>
+    <string name="dirac_headset_title">Seleccione el tipo de audífonos</string>
+    <string name="dirac_title">Potenciador de Mi Sonido</string>
+    <string name="dirac_preset_title">Preajuste</string>
+</resources>

--- a/parts/res/values-es/strings.xml
+++ b/parts/res/values-es/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clásica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electrónica</string>
+    <string name="dirac_default">Predefinido</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Cancelación de Ruido Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">General</string>
+    <string name="dirac_headset_general_inear">Normales In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Edición básica</string>
+    <string name="dirac_headset_piston_color">Edición a color</string>
+    <string name="dirac_headset_piston_standard">Edición estándar</string>
+    <string name="dirac_headset_piston_youth">Edición joven</string>
+    <string name="dirac_headset_reduction_noise">Cancelación de Ruido Mi Tipo C</string>
+    <string name="dirac_headset_title">Selecciona el tipo de auriculares</string>
+    <string name="dirac_title">Potenciador de Mi Sound</string>
+    <string name="dirac_preset_title">Preajuste</string>
+</resources>

--- a/parts/res/values-et-rEE/strings.xml
+++ b/parts/res/values-et-rEE/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Bluus</string>
+    <string name="dirac_preset_classical">Klassikaline</string>
+    <string name="dirac_preset_country">Riik</string>
+    <string name="dirac_preset_dance">Tants</string>
+    <string name="dirac_preset_electronic">Elektrooniline</string>
+    <string name="dirac_default">Vaikimisi</string>
+    <string name="dirac_preset_jazz">Džäss</string>
+    <string name="dirac_preset_metal">Metral</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Kivi</string>
+    <string name="dirac_headset_cancelling">Mi müra tühistamine 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Kapsul</string>
+    <string name="dirac_headset_earbuds">Mi Nööpkuularid</string>
+    <string name="dirac_headset_general">Üldidne</string>
+    <string name="dirac_headset_general_inear">Üldised kõrvasisesed</string>
+    <string name="dirac_headset_half_in_ear">Kõrvasisene Mi Half</string>
+    <string name="dirac_headset_headphone">Mi Kõrvaklapid</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi Kõrvasisesed</string>
+    <string name="dirac_headset_in_ear2">Kõrvasisene Mi 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi Kõrvasisesed (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi Kõrvasisesed Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Põhiväljalase</string>
+    <string name="dirac_headset_piston_color">Värviline väljalase</string>
+    <string name="dirac_headset_piston_standard">Standardväljalase</string>
+    <string name="dirac_headset_piston_youth">Noorte väljalase</string>
+    <string name="dirac_headset_reduction_noise">Mi müra tühistamise C-tüüp</string>
+    <string name="dirac_headset_title">Valige kõrvaklapitüüp</string>
+    <string name="dirac_title">Mi Heli Parandaja</string>
+    <string name="dirac_preset_title">Eelseade</string>
+</resources>

--- a/parts/res/values-eu-rES/strings.xml
+++ b/parts/res/values-eu-rES/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Bluesa</string>
+    <string name="dirac_preset_classical">Klasikoa</string>
+    <string name="dirac_preset_country">Herrikoa</string>
+    <string name="dirac_preset_dance">Dantza</string>
+    <string name="dirac_preset_electronic">Elektronikoa</string>
+    <string name="dirac_default">Lehenetsia</string>
+    <string name="dirac_preset_jazz">Jazza</string>
+    <string name="dirac_preset_metal">Metala</string>
+    <string name="dirac_preset_pop">Popa</string>
+    <string name="dirac_preset_rock">Rock-a</string>
+    <string name="dirac_headset_cancelling">Mi Zarata Ezabagailua 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Kapsula</string>
+    <string name="dirac_headset_earbuds">Mi Audiofonoa</string>
+    <string name="dirac_headset_general">Orokorra</string>
+    <string name="dirac_headset_general_inear">In-Ear orokorra</string>
+    <string name="dirac_headset_half_in_ear">Mi Half in Ear</string>
+    <string name="dirac_headset_headphone">Mi Entzungailuak</string>
+    <string name="dirac_headset_comfort">"Mi Comfort "</string>
+    <string name="dirac_headset_in_ear">"Mi In-Ear "</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">"Mi In-Ear (2013) "</string>
+    <string name="dirac_headset_in_ear_pro">"Mi In-Ear Pro "</string>
+    <string name="dirac_headset_piston_1">Mi Pistoia-1</string>
+    <string name="dirac_headset_piston_2">Mi Pistoia-2</string>
+    <string name="dirac_headset_piston_basic">Oinarrizko Edizioa</string>
+    <string name="dirac_headset_piston_color">Kolore Edizioa</string>
+    <string name="dirac_headset_piston_standard">Edizio arrunta</string>
+    <string name="dirac_headset_piston_youth">Gazte Edizioa</string>
+    <string name="dirac_headset_reduction_noise">Mi Zarata Ezabagailua C-Mota</string>
+    <string name="dirac_headset_title">Entzungailu mota aukeratu</string>
+    <string name="dirac_title">Mi Soinu indartzailea</string>
+    <string name="dirac_preset_title">Aurrez ezarritakoa</string>
+</resources>

--- a/parts/res/values-fa-rIR/strings.xml
+++ b/parts/res/values-fa-rIR/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">بلوز</string>
+    <string name="dirac_preset_classical">کلاسیک</string>
+    <string name="dirac_preset_country">روستایی</string>
+    <string name="dirac_preset_dance">رقص</string>
+    <string name="dirac_preset_electronic">الکترونیک</string>
+    <string name="dirac_default">پیش‌فرض</string>
+    <string name="dirac_preset_jazz">جاز</string>
+    <string name="dirac_preset_metal">متال</string>
+    <string name="dirac_preset_pop">پاپ</string>
+    <string name="dirac_preset_rock">راک</string>
+    <string name="dirac_headset_cancelling">کاهنده اختلال صدای Mi ۳.۵ میلی‌متری</string>
+    <string name="dirac_headset_capsule">کپسول Mi</string>
+    <string name="dirac_headset_earbuds">ریز هدفون Mi</string>
+    <string name="dirac_headset_general">عمومی</string>
+    <string name="dirac_headset_general_inear">درون گوشی عمومی</string>
+    <string name="dirac_headset_half_in_ear">نیم‌درون گوشی Mi</string>
+    <string name="dirac_headset_headphone">هدفون Mi</string>
+    <string name="dirac_headset_comfort">Mi آسوده</string>
+    <string name="dirac_headset_in_ear">درون گوشی Mi</string>
+    <string name="dirac_headset_in_ear2">درون گوشی Mi ۲</string>
+    <string name="dirac_headset_in_ear_2013">درون گوشی Mi (۲۰۱۳)</string>
+    <string name="dirac_headset_in_ear_pro">درون گوشی Mi حرفه‌ای</string>
+    <string name="dirac_headset_piston_1">پیستون Mi-۱</string>
+    <string name="dirac_headset_piston_2">پیستون Mi-۲</string>
+    <string name="dirac_headset_piston_basic">نسخه پایه</string>
+    <string name="dirac_headset_piston_color">نسخه رنگی</string>
+    <string name="dirac_headset_piston_standard">نسخه استاندارد</string>
+    <string name="dirac_headset_piston_youth">نسخه جوانان</string>
+    <string name="dirac_headset_reduction_noise">کاهنده اختلال صدای Mi نوع C</string>
+    <string name="dirac_headset_title">نوع هدفون‌ها را انتخاب کنید</string>
+    <string name="dirac_title">تقویت‌کننده صدای Mi</string>
+    <string name="dirac_preset_title">پیش‌تنظیم</string>
+</resources>

--- a/parts/res/values-fi/strings.xml
+++ b/parts/res/values-fi/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassinen</string>
+    <string name="dirac_preset_country">Kantri</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektroninen</string>
+    <string name="dirac_default">Oletus</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metalli</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Melunvaimennus 3,5 mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi-nappikuulokkeet</string>
+    <string name="dirac_headset_general">Yleinen</string>
+    <string name="dirac_headset_general_inear">Yleinen kuuloke</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi-kuulokkeet</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Perusversio</string>
+    <string name="dirac_headset_piston_color">Värillinen versio</string>
+    <string name="dirac_headset_piston_standard">Vakioversio</string>
+    <string name="dirac_headset_piston_youth">Nuorisoversio</string>
+    <string name="dirac_headset_reduction_noise">Mi Melunvaimennus Type-C</string>
+    <string name="dirac_headset_title">Valitse kuuloke tyyppi</string>
+    <string name="dirac_title">Mi-äänentehostaja</string>
+    <string name="dirac_preset_title">Esiaseta</string>
+</resources>

--- a/parts/res/values-fr/strings.xml
+++ b/parts/res/values-fr/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Classique</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electronic</string>
+    <string name="dirac_default">Par défaut</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Métal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Élimination de bruit 3,5 mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Écouteurs Mi</string>
+    <string name="dirac_headset_general">Général</string>
+    <string name="dirac_headset_general_inear">Intra générique</string>
+    <string name="dirac_headset_half_in_ear">Mi Half in-Ear</string>
+    <string name="dirac_headset_headphone">Casque Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Intra Mi</string>
+    <string name="dirac_headset_in_ear2">Écouteurs intra Mi 2</string>
+    <string name="dirac_headset_in_ear_2013">Écouteurs intra Mi (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Intra Mi Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Édition basique</string>
+    <string name="dirac_headset_piston_color">Édition colorée</string>
+    <string name="dirac_headset_piston_standard">Édition standard</string>
+    <string name="dirac_headset_piston_youth">Édition Jeunesse</string>
+    <string name="dirac_headset_reduction_noise">Mi Élimination de bruit Type C</string>
+    <string name="dirac_headset_title">"Sélectionnez le type d'écouteurs"</string>
+    <string name="dirac_title">Amélioration audio Mi</string>
+    <string name="dirac_preset_title">Pré-définir</string>
+</resources>

--- a/parts/res/values-gl-rES/strings.xml
+++ b/parts/res/values-gl-rES/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clásica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electrónica</string>
+    <string name="dirac_default">Predefinido</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Cancelación de Mi Noise 3,5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Xeral</string>
+    <string name="dirac_headset_general_inear">Manos libres xeral</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Auriculares Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">Edición básica</string>
+    <string name="dirac_headset_piston_color">Edición a cor</string>
+    <string name="dirac_headset_piston_standard">Edición estándar</string>
+    <string name="dirac_headset_piston_youth">Edición mocidade</string>
+    <string name="dirac_headset_reduction_noise">Cancelación de Mi Noise TipoC</string>
+    <string name="dirac_headset_title">Seleccionar o tipo de auriculares</string>
+    <string name="dirac_title">Potenciador Mi Sound</string>
+    <string name="dirac_preset_title">Predefinido</string>
+</resources>

--- a/parts/res/values-gu-rIN/strings.xml
+++ b/parts/res/values-gu-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">બ્લૂઝ</string>
+    <string name="dirac_preset_classical">ક્લાસિકલ</string>
+    <string name="dirac_preset_country">દેશ</string>
+    <string name="dirac_preset_dance">નૃત્ય</string>
+    <string name="dirac_preset_electronic">ઇલેક્ટ્રોનિક</string>
+    <string name="dirac_default">ડિફૉલ્ટ</string>
+    <string name="dirac_preset_jazz">જૅઝ</string>
+    <string name="dirac_preset_metal">મેટલ</string>
+    <string name="dirac_preset_pop">પૉપ</string>
+    <string name="dirac_preset_rock">રૉક</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi કેપ્સ્યુલ</string>
+    <string name="dirac_headset_earbuds">Mi ઇયરબડ</string>
+    <string name="dirac_headset_general">સામાન્ય</string>
+    <string name="dirac_headset_general_inear">સામાન્ય ઇન-ઇયર</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">માઇલ હેડફોન</string>
+    <string name="dirac_headset_comfort">Mi આરામ</string>
+    <string name="dirac_headset_in_ear">Mi ઇન-ઇયર</string>
+    <string name="dirac_headset_in_ear2">Mi ઇન-ઇઅર 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ઇન-ઇઅર (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ઇન-ઇઅર પ્રો</string>
+    <string name="dirac_headset_piston_1">માઇલ પિસ્ટન 1</string>
+    <string name="dirac_headset_piston_2">માઇલ પિસ્ટન 2</string>
+    <string name="dirac_headset_piston_basic">મૂળભૂત આવૃત્તિ</string>
+    <string name="dirac_headset_piston_color">રંગ આવૃત્તિ</string>
+    <string name="dirac_headset_piston_standard">સ્ટાન્ડર્ડ આવૃત્તિ</string>
+    <string name="dirac_headset_piston_youth">યુવા આવૃત્તિ</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">હેડફોન પ્રકાર પસંદ કરો</string>
+    <string name="dirac_title">Mi સાઉન્ડ એન્હાંસર</string>
+    <string name="dirac_preset_title">પ્રીસેટ</string>
+</resources>

--- a/parts/res/values-ha-rNG/strings.xml
+++ b/parts/res/values-ha-rNG/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Gargajiya</string>
+    <string name="dirac_preset_country">Ƙasa</string>
+    <string name="dirac_preset_dance">Rawa</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Na asali</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Mital</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rok</string>
+    <string name="dirac_headset_cancelling">Sokewar Hayaniyar Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Na Genaral</string>
+    <string name="dirac_headset_general_inear">Na General In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">"Na'urar kunni na Mi"</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">Bugu Na asali</string>
+    <string name="dirac_headset_piston_color">Bugu na launi</string>
+    <string name="dirac_headset_piston_standard">Bugu na Daidai</string>
+    <string name="dirac_headset_piston_youth">Bugu na matasa</string>
+    <string name="dirac_headset_reduction_noise">Sokewar Hayaniyar Mi Irin-C</string>
+    <string name="dirac_headset_title">"Zabin irin na'urar ji ta kunni"</string>
+    <string name="dirac_title">Kyautata Sautin Mi</string>
+    <string name="dirac_preset_title">Setin farko</string>
+</resources>

--- a/parts/res/values-hi/strings.xml
+++ b/parts/res/values-hi/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ब्लूज़</string>
+    <string name="dirac_preset_classical">क्लॅसिकल</string>
+    <string name="dirac_preset_country">कंट्री</string>
+    <string name="dirac_preset_dance">डांस</string>
+    <string name="dirac_preset_electronic">इलेक्ट्रॉनिक</string>
+    <string name="dirac_default">डिफ़ॉल्ट</string>
+    <string name="dirac_preset_jazz">जैज़</string>
+    <string name="dirac_preset_metal">मेटल</string>
+    <string name="dirac_preset_pop">पॉप</string>
+    <string name="dirac_preset_rock">रॉक</string>
+    <string name="dirac_headset_cancelling">Mi नॉइज कैंसलिंग 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi कैपसूल</string>
+    <string name="dirac_headset_earbuds">Mi इयरबड्स</string>
+    <string name="dirac_headset_general">सामान्य</string>
+    <string name="dirac_headset_general_inear">सामान्य इन-इयर</string>
+    <string name="dirac_headset_half_in_ear">Mi हाल्फ इन ईयर</string>
+    <string name="dirac_headset_headphone">Mi हेडफ़ोन्स</string>
+    <string name="dirac_headset_comfort">Mi आराम</string>
+    <string name="dirac_headset_in_ear">Mi इन-इयर</string>
+    <string name="dirac_headset_in_ear2">Mi इन-ईयर 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi इन-ईयर (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi इन-ईयर प्रो</string>
+    <string name="dirac_headset_piston_1">Mi पिस्टन-1</string>
+    <string name="dirac_headset_piston_2">Mi पिस्टन-2</string>
+    <string name="dirac_headset_piston_basic">मूल संस्करण</string>
+    <string name="dirac_headset_piston_color">रंग संस्करण</string>
+    <string name="dirac_headset_piston_standard">मानक संस्करण</string>
+    <string name="dirac_headset_piston_youth">युवा संस्करण</string>
+    <string name="dirac_headset_reduction_noise">Mi नॉइज कैंसलिंग टाइप-C</string>
+    <string name="dirac_headset_title">हेडफ़ोन प्रकार चुनें</string>
+    <string name="dirac_title">Mi ध्वनि एन्हांसर</string>
+    <string name="dirac_preset_title">प्रीसेट</string>
+</resources>

--- a/parts/res/values-hr/strings.xml
+++ b/parts/res/values-hr/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasična</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electronic</string>
+    <string name="dirac_default">Zadano</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise otkazivanje 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Općenito</string>
+    <string name="dirac_headset_general_inear">Općenito In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi slušalice</string>
+    <string name="dirac_headset_comfort">Mi Komfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Osnovno Izdanje</string>
+    <string name="dirac_headset_piston_color">Izdanje u boji</string>
+    <string name="dirac_headset_piston_standard">Standardno izdanje</string>
+    <string name="dirac_headset_piston_youth">Izdanje za mlade</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise otkazivanje buke tip-C</string>
+    <string name="dirac_headset_title">Odaberite vrstu slušalica</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Pred-postavke</string>
+</resources>

--- a/parts/res/values-hu/strings.xml
+++ b/parts/res/values-hu/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasszikus</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronikus</string>
+    <string name="dirac_default">Alapértelmezett</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metál</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Zajcsökkentés 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi fülhallgató</string>
+    <string name="dirac_headset_general">Általános</string>
+    <string name="dirac_headset_general_inear">Általános fülhallgató</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi fejhallgató</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi fülhallgató</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic kiadás</string>
+    <string name="dirac_headset_piston_color">Színes kiadás</string>
+    <string name="dirac_headset_piston_standard">Standard kiadás</string>
+    <string name="dirac_headset_piston_youth">Youth kiadás</string>
+    <string name="dirac_headset_reduction_noise">Mi Zajcsökkentés Type-C</string>
+    <string name="dirac_headset_title">Fülhallgató típusa</string>
+    <string name="dirac_title">Mi Hangjavítás</string>
+    <string name="dirac_preset_title">Csatorna</string>
+</resources>

--- a/parts/res/values-hy-rAM/strings.xml
+++ b/parts/res/values-hy-rAM/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Բլյուզ</string>
+    <string name="dirac_preset_classical">Դասական</string>
+    <string name="dirac_preset_country">Քանտրի</string>
+    <string name="dirac_preset_dance">Պար</string>
+    <string name="dirac_preset_electronic">Էլեկտրոնային</string>
+    <string name="dirac_default">Կանխադրված</string>
+    <string name="dirac_preset_jazz">Ջազ</string>
+    <string name="dirac_preset_metal">Մետալ</string>
+    <string name="dirac_preset_pop">Փոփ</string>
+    <string name="dirac_preset_rock">Ռոք</string>
+    <string name="dirac_headset_cancelling">Mi Աղմուկի Չեղարկում 3.5մմ</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Սովորական</string>
+    <string name="dirac_headset_general_inear">Սովորական ներդրվող</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi ականջակալներ</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi ներդրվող</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ներդրվող (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ներդրվող Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Հիմնական տարբերակ</string>
+    <string name="dirac_headset_piston_color">Գունավոր տարբերակ</string>
+    <string name="dirac_headset_piston_standard">Ստանդարտ տարբերակ</string>
+    <string name="dirac_headset_piston_youth">Երիտասարդական տարբերակ</string>
+    <string name="dirac_headset_reduction_noise">Mi Աղմուկի Չեղարկում Տիպ C</string>
+    <string name="dirac_headset_title">Ընտրել ականջակալների տեսակը</string>
+    <string name="dirac_title">Mi Ձայնի բարելավում</string>
+    <string name="dirac_preset_title">Նախնական կարգավորում</string>
+</resources>

--- a/parts/res/values-in/strings.xml
+++ b/parts/res/values-in/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasik</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Bawaan</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3,5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Umum</string>
+    <string name="dirac_headset_general_inear">In-Ear umum</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphone</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston 1</string>
+    <string name="dirac_headset_piston_2">Mi Piston 2</string>
+    <string name="dirac_headset_piston_basic">Edisi Basic</string>
+    <string name="dirac_headset_piston_color">Edisi Warna</string>
+    <string name="dirac_headset_piston_standard">Edisi standar</string>
+    <string name="dirac_headset_piston_youth">Edisi Youth</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Pilih tipe headphone</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Preset</string>
+</resources>

--- a/parts/res/values-it/strings.xml
+++ b/parts/res/values-it/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Classica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elettronica</string>
+    <string name="dirac_default">Predefinito</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Cancellazione Rumore Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Auricolari Mi</string>
+    <string name="dirac_headset_general">Generale</string>
+    <string name="dirac_headset_general_inear">In-Ear generiche</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Cuffie Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Edizione base</string>
+    <string name="dirac_headset_piston_color">Edizione Color</string>
+    <string name="dirac_headset_piston_standard">Edizione Standard</string>
+    <string name="dirac_headset_piston_youth">Edizione Youth</string>
+    <string name="dirac_headset_reduction_noise">Cancellazione Rumore Mi Type-C</string>
+    <string name="dirac_headset_title">Scegli il tipo di cuffie</string>
+    <string name="dirac_title">Ottimizzazione Mi Sound</string>
+    <string name="dirac_preset_title">Preimpostazione</string>
+</resources>

--- a/parts/res/values-iw-rIL/strings.xml
+++ b/parts/res/values-iw-rIL/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">בלוז</string>
+    <string name="dirac_preset_classical">קלאסית</string>
+    <string name="dirac_preset_country">קאנטרי</string>
+    <string name="dirac_preset_dance">דאנס</string>
+    <string name="dirac_preset_electronic">אלקטרונית</string>
+    <string name="dirac_default">ברירת מחדל</string>
+    <string name="dirac_preset_jazz">"ג'אז"</string>
+    <string name="dirac_preset_metal">מטאל</string>
+    <string name="dirac_preset_pop">פופ</string>
+    <string name="dirac_preset_rock">רוק</string>
+    <string name="dirac_headset_cancelling">ביטול רעשים של Mi 3.5 מ\"מ</string>
+    <string name="dirac_headset_capsule">קפסולת Mi</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">כללי</string>
+    <string name="dirac_headset_general_inear">In-Ear כללי</string>
+    <string name="dirac_headset_half_in_ear">Mi Half in Ear</string>
+    <string name="dirac_headset_headphone">אוזניות Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">מהדורה בסיסית</string>
+    <string name="dirac_headset_piston_color">מהדורת צבע</string>
+    <string name="dirac_headset_piston_standard">מהודרה רגילה</string>
+    <string name="dirac_headset_piston_youth">מהדורת נוער</string>
+    <string name="dirac_headset_reduction_noise">ביטול רעשים של Mi Type-C</string>
+    <string name="dirac_headset_title">בחר סוג אוזניות</string>
+    <string name="dirac_title">מגבר צלילים Mi</string>
+    <string name="dirac_preset_title">קבוע מראש</string>
+</resources>

--- a/parts/res/values-ja/strings.xml
+++ b/parts/res/values-ja/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ブルース</string>
+    <string name="dirac_preset_classical">クラシック</string>
+    <string name="dirac_preset_country">カントリー</string>
+    <string name="dirac_preset_dance">ダンス</string>
+    <string name="dirac_preset_electronic">エレクトロニック</string>
+    <string name="dirac_default">デフォルト</string>
+    <string name="dirac_preset_jazz">ジャズ</string>
+    <string name="dirac_preset_metal">メタル</string>
+    <string name="dirac_preset_pop">ポップ</string>
+    <string name="dirac_preset_rock">ロック</string>
+    <string name="dirac_headset_cancelling">Mi ノイズキャンセリング 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi カプセル</string>
+    <string name="dirac_headset_earbuds">Mi イヤーバッド</string>
+    <string name="dirac_headset_general">一般</string>
+    <string name="dirac_headset_general_inear">一般的なインイヤー型</string>
+    <string name="dirac_headset_half_in_ear">Mi ハーフインイヤー</string>
+    <string name="dirac_headset_headphone">Mi ヘッドフォン</string>
+    <string name="dirac_headset_comfort">Mi コンフォート</string>
+    <string name="dirac_headset_in_ear">Mi インイヤー</string>
+    <string name="dirac_headset_in_ear2">Mi インイヤー2</string>
+    <string name="dirac_headset_in_ear_2013">Mi インイヤー (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi インイヤー Pro</string>
+    <string name="dirac_headset_piston_1">Mi ピストン-1</string>
+    <string name="dirac_headset_piston_2">Mi ピストン-2</string>
+    <string name="dirac_headset_piston_basic">ベーシック版</string>
+    <string name="dirac_headset_piston_color">カラー版</string>
+    <string name="dirac_headset_piston_standard">スタンダード版</string>
+    <string name="dirac_headset_piston_youth">青春版</string>
+    <string name="dirac_headset_reduction_noise">Mi ノイズキャンセリング Type-C</string>
+    <string name="dirac_headset_title">ヘッドフォンの種類を選択</string>
+    <string name="dirac_title">Mi サウンドエンハンサー</string>
+    <string name="dirac_preset_title">プリセット</string>
+</resources>

--- a/parts/res/values-ka-rGE/strings.xml
+++ b/parts/res/values-ka-rGE/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ბლუზი</string>
+    <string name="dirac_preset_classical">კლასიკური</string>
+    <string name="dirac_preset_country">ქვეყანა</string>
+    <string name="dirac_preset_dance">ცეკვა</string>
+    <string name="dirac_preset_electronic">ელექტრონული</string>
+    <string name="dirac_default">დათქმული</string>
+    <string name="dirac_preset_jazz">ჯაზი</string>
+    <string name="dirac_preset_metal">მეტალი</string>
+    <string name="dirac_preset_pop">პოპი</string>
+    <string name="dirac_preset_rock">როკი</string>
+    <string name="dirac_headset_cancelling">Mi Noise აუქმებს 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi კაპსულა</string>
+    <string name="dirac_headset_earbuds">Mi ყურსასმენი</string>
+    <string name="dirac_headset_general">მთავარი</string>
+    <string name="dirac_headset_general_inear">მთავარი ყურსასმენი</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi ყურსასმენები</string>
+    <string name="dirac_headset_comfort">Mi Comfort-ი</string>
+    <string name="dirac_headset_in_ear">Mi ყურს შიდა</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ყურსასმენი (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ყურსასმენი Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">ძირითადი ედიცია</string>
+    <string name="dirac_headset_piston_color">ფერადი ედიცია</string>
+    <string name="dirac_headset_piston_standard">სტანდარტული ედიცია</string>
+    <string name="dirac_headset_piston_youth">ახალგაზრდული ედიცია</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise აუქმებს Type-C</string>
+    <string name="dirac_headset_title">ყურსასმენის ტიპის არჩევა</string>
+    <string name="dirac_title">Mi ხმის გამაუმჯობესებელი</string>
+    <string name="dirac_preset_title">მიმდინარე</string>
+</resources>

--- a/parts/res/values-kk-rKZ/strings.xml
+++ b/parts/res/values-kk-rKZ/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блюз</string>
+    <string name="dirac_preset_classical">Классикалық</string>
+    <string name="dirac_preset_country">Кантри</string>
+    <string name="dirac_preset_dance">Би</string>
+    <string name="dirac_preset_electronic">Электро</string>
+    <string name="dirac_default">Әдепкі</string>
+    <string name="dirac_preset_jazz">Джаз</string>
+    <string name="dirac_preset_metal">Металл</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi Шуыл Болдырылмауда 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule (капсулалық)</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds (ішпектер)</string>
+    <string name="dirac_headset_general">Кәдімгі құлаққаптар</string>
+    <string name="dirac_headset_general_inear">Кәдімгі арнаішілік</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones (жапсырмалы)</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">"Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">"Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Mi Piston (базалық нұсқа)</string>
+    <string name="dirac_headset_piston_color">Mi Piston (түсті нұсқа)</string>
+    <string name="dirac_headset_piston_standard">Mi Piston (стандартты нұсқа)</string>
+    <string name="dirac_headset_piston_youth">Mi Piston (жастар нұсқасы)</string>
+    <string name="dirac_headset_reduction_noise">Mi Шуыл Болдырылмауда Type-C</string>
+    <string name="dirac_headset_title">Құлаққап түрлері</string>
+    <string name="dirac_title">Mi дыбыс жақсарту</string>
+    <string name="dirac_preset_title">Алдын ала орнатылған баптаулар</string>
+</resources>

--- a/parts/res/values-km-rKH/strings.xml
+++ b/parts/res/values-km-rKH/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">តន្រ្តីប្លូស៍</string>
+    <string name="dirac_preset_classical">បុរាណ</string>
+    <string name="dirac_preset_country">បែបជនបទ</string>
+    <string name="dirac_preset_dance">រាំ</string>
+    <string name="dirac_preset_electronic">អេឡិចត្រូនិក</string>
+    <string name="dirac_default">លំនាំដើម</string>
+    <string name="dirac_preset_jazz">ហ្សាស</string>
+    <string name="dirac_preset_metal">តន្ត្រីលោហៈ</string>
+    <string name="dirac_preset_pop">ប៉ប់</string>
+    <string name="dirac_preset_rock">ចង្វាក់​រ៉ុក</string>
+    <string name="dirac_headset_cancelling">ការលុបសម្លេងMi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">កាស Mi</string>
+    <string name="dirac_headset_general">ទូទៅ</string>
+    <string name="dirac_headset_general_inear">កាសស៊ករន្ធត្រចៀកទូទៅ</string>
+    <string name="dirac_headset_half_in_ear">កាសស៊កពាក់កណ្តាលរន្ធត្រចៀក​ Mi​</string>
+    <string name="dirac_headset_headphone">កាស Mi ទាំងឡាយ</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">កាសស៊ករន្ធត្រចៀក​ Mi</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear ២</string>
+    <string name="dirac_headset_in_ear_2013">កាសស៊ករន្ធត្រចៀក​ Mi (2013)</string>
+    <string name="dirac_headset_in_ear_pro">កាសស៊ករន្ធត្រចៀក​ Mi​ Pro</string>
+    <string name="dirac_headset_piston_1">ប៊ីស្ដុង Mi - 1</string>
+    <string name="dirac_headset_piston_2">Mi ប៊ីស្ដុង - 2</string>
+    <string name="dirac_headset_piston_basic">ម៉ូដែលកាសធម្មតា</string>
+    <string name="dirac_headset_piston_color">ម៉ូដែលកាស​ Color</string>
+    <string name="dirac_headset_piston_standard">ម៉ូដែលកាសស្តង់ដា</string>
+    <string name="dirac_headset_piston_youth">ម៉ូដែលកាស​ Youth</string>
+    <string name="dirac_headset_reduction_noise">ការលុបសម្លេងMi ប្រភេទ -C</string>
+    <string name="dirac_headset_title">ជ្រើសប្រភេទកាស</string>
+    <string name="dirac_title">បង្កើនគុណភាពសម្លេង Mi</string>
+    <string name="dirac_preset_title">កំណត់ជាមុន</string>
+</resources>

--- a/parts/res/values-kn-rIN/strings.xml
+++ b/parts/res/values-kn-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ಬ್ಲೂಸ್</string>
+    <string name="dirac_preset_classical">ಕ್ಲಾಸಿಕಲ್‌</string>
+    <string name="dirac_preset_country">ದೇಶೀಯ</string>
+    <string name="dirac_preset_dance">ಡ್ಯಾನ್ಸ್</string>
+    <string name="dirac_preset_electronic">ಎಲೆಕ್ಟ್ರಾನಿಕ್</string>
+    <string name="dirac_default">ಡೀಫಾಲ್ಟ್‌</string>
+    <string name="dirac_preset_jazz">ಜಾಝ್</string>
+    <string name="dirac_preset_metal">ಮೆಟಲ್‌</string>
+    <string name="dirac_preset_pop">ಪಾಪ್</string>
+    <string name="dirac_preset_rock">ರಾಕ್</string>
+    <string name="dirac_headset_cancelling">Mi ಸದ್ದು ರದ್ದುಗೊಳಿಸುವಿಕೆ 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi ಕ್ಯಾಪ್ಸೂಲ್</string>
+    <string name="dirac_headset_earbuds">Mi ಇಯರ್‌‌ಬಡ್ಸ್</string>
+    <string name="dirac_headset_general">ಸಾಮಾನ್ಯ</string>
+    <string name="dirac_headset_general_inear">ಸಾಮಾನ್ಯ ಇನ್-ಇಯರ್</string>
+    <string name="dirac_headset_half_in_ear">Mi ಹಾಫ್ ಇನ್ ಇಯರ್</string>
+    <string name="dirac_headset_headphone">Mi ಹೆಡ್‌ಫೋನ್‌ಗಳು</string>
+    <string name="dirac_headset_comfort">Mi ಕಂಫರ್ಟ್‌</string>
+    <string name="dirac_headset_in_ear">Mi ಇನ್-ಇಯರ್</string>
+    <string name="dirac_headset_in_ear2">Mi ಇನ್‌-ಇಯರ್‌ 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ಇನ್‌-ಇಯರ್‌ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ಇನ್‌-ಇಯರ್‌ ಪ್ರೋ</string>
+    <string name="dirac_headset_piston_1">Mi ಪಿಸ್ಟನ್-1</string>
+    <string name="dirac_headset_piston_2">Mi ಪಿಸ್ಟನ್-2</string>
+    <string name="dirac_headset_piston_basic">ಮೂಲ ಆವೃತ್ತಿ</string>
+    <string name="dirac_headset_piston_color">ಬಣ್ಣದ ಆವೃತ್ತಿ</string>
+    <string name="dirac_headset_piston_standard">ಪ್ರಮಾಣಿತ ಆವೃತ್ತಿ</string>
+    <string name="dirac_headset_piston_youth">ಯುವ ಆವೃತ್ತಿ</string>
+    <string name="dirac_headset_reduction_noise">Mi ಸದ್ದು ರದ್ದುಗೊಳಿಸುವಿಕೆ ಪ್ರಕಾರ-C</string>
+    <string name="dirac_headset_title">ಹೆಡ್‌‌ಫೋನ್‌ಗಳ ವಿಧವನ್ನು ಆರಿಸಿ</string>
+    <string name="dirac_title">Mi ಧ್ವನಿ ಎನ್‌ಹ್ಯಾನ್ಸರ್‌‌</string>
+    <string name="dirac_preset_title">ಪ್ರೀಸೆಟ್</string>
+</resources>

--- a/parts/res/values-ko/strings.xml
+++ b/parts/res/values-ko/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">블루스</string>
+    <string name="dirac_preset_classical">클래식</string>
+    <string name="dirac_preset_country">컨트리</string>
+    <string name="dirac_preset_dance">댄스</string>
+    <string name="dirac_preset_electronic">일렉트로닉</string>
+    <string name="dirac_default">기본</string>
+    <string name="dirac_preset_jazz">재즈</string>
+    <string name="dirac_preset_metal">메탈</string>
+    <string name="dirac_preset_pop">팝</string>
+    <string name="dirac_preset_rock">락</string>
+    <string name="dirac_headset_cancelling">Mi 노이즈 캔슬링 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi 캡슐</string>
+    <string name="dirac_headset_earbuds">Mi 이어버드</string>
+    <string name="dirac_headset_general">일반</string>
+    <string name="dirac_headset_general_inear">일반 이어폰</string>
+    <string name="dirac_headset_half_in_ear">Mi 하프 인이어</string>
+    <string name="dirac_headset_headphone">Mi 헤드폰</string>
+    <string name="dirac_headset_comfort">Mi 컴포트</string>
+    <string name="dirac_headset_in_ear">Mi 이어폰</string>
+    <string name="dirac_headset_in_ear2">Mi 인이어 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi 인이어 (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi 인이어 프로</string>
+    <string name="dirac_headset_piston_1">Mi 피스톤 1</string>
+    <string name="dirac_headset_piston_2">Mi 피스톤 2</string>
+    <string name="dirac_headset_piston_basic">기본 에디션</string>
+    <string name="dirac_headset_piston_color">컬러 에디션</string>
+    <string name="dirac_headset_piston_standard">표준 에디션</string>
+    <string name="dirac_headset_piston_youth">청소년 에디션</string>
+    <string name="dirac_headset_reduction_noise">Mi 노이즈 캔슬링 Type-C</string>
+    <string name="dirac_headset_title">헤드폰 유형 선택</string>
+    <string name="dirac_title">Mi 사운드 강화</string>
+    <string name="dirac_preset_title">프리셋</string>
+</resources>

--- a/parts/res/values-lo-rLA/strings.xml
+++ b/parts/res/values-lo-rLA/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">ຄລາສສິກ</string>
+    <string name="dirac_preset_country">ຄັນທຣີ່</string>
+    <string name="dirac_preset_dance">ເຕັ້ນ</string>
+    <string name="dirac_preset_electronic">ເອເລັກໂຕຣນິກ</string>
+    <string name="dirac_default">ຄ່າເລີ່ມຕົ້ນ</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">ຣັອກ</string>
+    <string name="dirac_headset_cancelling">Mi ຕັດສຽງລົບກວນ 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">​ທົ່ວ​ໄປ</string>
+    <string name="dirac_headset_general_inear">ຫູຟັງ In-Ear ທົ່ວໄປ</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">ຫູຟັງ Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">ພື້ນຖານ</string>
+    <string name="dirac_headset_piston_color">ຮຸ່ນສີສັນ</string>
+    <string name="dirac_headset_piston_standard">ມາດຕະຖານ</string>
+    <string name="dirac_headset_piston_youth">ຮຸ່ນໄວໜຸ່ມ</string>
+    <string name="dirac_headset_reduction_noise">Mi ຕັດສຽງລົບກວນ Type-C</string>
+    <string name="dirac_headset_title">ເລືອກປະເພດຫູຟັງ</string>
+    <string name="dirac_title">ຕົວເພີ່ມປະສິດທິພາບສຽງ Mi</string>
+    <string name="dirac_preset_title">ຄ່າທີ່ຕັ້ງໄວ້</string>
+</resources>

--- a/parts/res/values-lt/strings.xml
+++ b/parts/res/values-lt/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Bliuzas</string>
+    <string name="dirac_preset_classical">Klasika</string>
+    <string name="dirac_preset_country">Kantri</string>
+    <string name="dirac_preset_dance">Šokių</string>
+    <string name="dirac_preset_electronic">Elektronika</string>
+    <string name="dirac_default">Numatytasis</string>
+    <string name="dirac_preset_jazz">Džiazas</string>
+    <string name="dirac_preset_metal">Metalas</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rokas</string>
+    <string name="dirac_headset_cancelling">„Mi“ triukšmo mažinimas (3.5mm)</string>
+    <string name="dirac_headset_capsule">Mi Kapsulė</string>
+    <string name="dirac_headset_earbuds">Mi Ausinės</string>
+    <string name="dirac_headset_general">Įprastos ausinės</string>
+    <string name="dirac_headset_general_inear">Paprastos įkišamos ausinės</string>
+    <string name="dirac_headset_half_in_ear">„Mi Half in Ear“</string>
+    <string name="dirac_headset_headphone">Mi Ausinės</string>
+    <string name="dirac_headset_comfort">Mi Komfortas</string>
+    <string name="dirac_headset_in_ear">Mi Įkišamos ausinės</string>
+    <string name="dirac_headset_in_ear2">„Mi In-Ear 2“</string>
+    <string name="dirac_headset_in_ear_2013">„Mi In-Ear“ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">„Mi In-Ear Pro“</string>
+    <string name="dirac_headset_piston_1">„Mi Piston-1“</string>
+    <string name="dirac_headset_piston_2">„Mi Piston-2“</string>
+    <string name="dirac_headset_piston_basic">Įprastos kamštinės</string>
+    <string name="dirac_headset_piston_color">Spalvų Leidimas</string>
+    <string name="dirac_headset_piston_standard">Standartinis Leidimas</string>
+    <string name="dirac_headset_piston_youth">Jaunimo Leidimas</string>
+    <string name="dirac_headset_reduction_noise">„Mi“ triukšmo mažinimas (Tipas-C)</string>
+    <string name="dirac_headset_title">Pasirinkite ausinių tipą</string>
+    <string name="dirac_title">„Mi garso pagerinimas“</string>
+    <string name="dirac_preset_title">Ruošinys</string>
+</resources>

--- a/parts/res/values-lv/strings.xml
+++ b/parts/res/values-lv/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blūzs</string>
+    <string name="dirac_preset_classical">Klasiskā mūzika</string>
+    <string name="dirac_preset_country">Kantrī mūzika</string>
+    <string name="dirac_preset_dance">Deju mūzika</string>
+    <string name="dirac_preset_electronic">Elektroniskā mūzika</string>
+    <string name="dirac_default">Noklusējums</string>
+    <string name="dirac_preset_jazz">Džezs</string>
+    <string name="dirac_preset_metal">Metāls</string>
+    <string name="dirac_preset_pop">Popmūzika</string>
+    <string name="dirac_preset_rock">Roks</string>
+    <string name="dirac_headset_cancelling">Mi trokšņu slāpēšana 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Kapsula</string>
+    <string name="dirac_headset_earbuds">Mi ieauši</string>
+    <string name="dirac_headset_general">Vispārīgi</string>
+    <string name="dirac_headset_general_inear">Vispārīgas ausīs liekamas</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Austiņas</string>
+    <string name="dirac_headset_comfort">Mi Komforts</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Pamata modelis</string>
+    <string name="dirac_headset_piston_color">Krāsu modelis</string>
+    <string name="dirac_headset_piston_standard">Standarta modelis</string>
+    <string name="dirac_headset_piston_youth">Jauniešu modelis</string>
+    <string name="dirac_headset_reduction_noise">Mi Trokšņu Slāpēšana Tips-C</string>
+    <string name="dirac_headset_title">Izvēlieties austiņu tipu</string>
+    <string name="dirac_title">Mi skaņas pastiprinātājs</string>
+    <string name="dirac_preset_title">Iestatījums</string>
+</resources>

--- a/parts/res/values-mk-rMK/strings.xml
+++ b/parts/res/values-mk-rMK/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блус</string>
+    <string name="dirac_preset_classical">Класично</string>
+    <string name="dirac_preset_country">Кантри</string>
+    <string name="dirac_preset_dance">Денс</string>
+    <string name="dirac_preset_electronic">Електронска</string>
+    <string name="dirac_default">Стандардно</string>
+    <string name="dirac_preset_jazz">Џез</string>
+    <string name="dirac_preset_metal">Метал</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi намалување на врева 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi “Capsule“</string>
+    <string name="dirac_headset_earbuds">Mi “Earbuds“</string>
+    <string name="dirac_headset_general">Обични</string>
+    <string name="dirac_headset_general_inear">Обични “in-ear“</string>
+    <string name="dirac_headset_half_in_ear">Слушалки Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi слушалки</string>
+    <string name="dirac_headset_comfort">Mi “Comfort“</string>
+    <string name="dirac_headset_in_ear">Mi “In-Ear“</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi “In-Ear“ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi “In-Ear Pro“</string>
+    <string name="dirac_headset_piston_1">Mi “Piston-1“</string>
+    <string name="dirac_headset_piston_2">Mi “Piston-2“</string>
+    <string name="dirac_headset_piston_basic">Обични слушалки</string>
+    <string name="dirac_headset_piston_color">Слушалки во боја</string>
+    <string name="dirac_headset_piston_standard">Стандардни слушалки</string>
+    <string name="dirac_headset_piston_youth">Младешки слушалки</string>
+    <string name="dirac_headset_reduction_noise">Mi откажување на врева тип-C</string>
+    <string name="dirac_headset_title">Избери вид слушалки</string>
+    <string name="dirac_title">Mi Sound засилувач</string>
+    <string name="dirac_preset_title">Поставки</string>
+</resources>

--- a/parts/res/values-ml-rIN/strings.xml
+++ b/parts/res/values-ml-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ദുഃഖഭാവമുള്ള</string>
+    <string name="dirac_preset_classical">ക്ലാസിക്കൽ</string>
+    <string name="dirac_preset_country">രാജ്യം</string>
+    <string name="dirac_preset_dance">ഡാൻസ്</string>
+    <string name="dirac_preset_electronic">ഇലക്ട്രോണിക്ക്</string>
+    <string name="dirac_default">ഡിഫോൾട്ട്</string>
+    <string name="dirac_preset_jazz">ജാസ്സ്</string>
+    <string name="dirac_preset_metal">മെറ്റൽ</string>
+    <string name="dirac_preset_pop">പോപ്പ്</string>
+    <string name="dirac_preset_rock">റോക്ക്</string>
+    <string name="dirac_headset_cancelling">Mi നോയ്സ് റദ്ദാക്കൽ 3.5മിമീ</string>
+    <string name="dirac_headset_capsule">Mi ക്യാപ്സ്യൂൾ</string>
+    <string name="dirac_headset_earbuds">Mi ഇയർബഡ്സുകൾ</string>
+    <string name="dirac_headset_general">പൊതുവായത്</string>
+    <string name="dirac_headset_general_inear">പൊതുവായത് ഇൻ-ഇയർ</string>
+    <string name="dirac_headset_half_in_ear">Mi ഹാഫ് ഇൻ ഇയർ</string>
+    <string name="dirac_headset_headphone">Mi ഹെഡ്‌ഫോണുകള്‍</string>
+    <string name="dirac_headset_comfort">Mi കംഫർട്ട്</string>
+    <string name="dirac_headset_in_ear">Mi ഇൻ-ഇയർ</string>
+    <string name="dirac_headset_in_ear2">Mi ഇൻ ഇയർ 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ഇൻ-ഇയർ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ഇൻ-ഇയർ പ്രോ</string>
+    <string name="dirac_headset_piston_1">Mi പിസ്റ്റൺ-1</string>
+    <string name="dirac_headset_piston_2">Mi പിസ്റ്റൺ-2</string>
+    <string name="dirac_headset_piston_basic">അടിസ്ഥാന എഡിഷൻ</string>
+    <string name="dirac_headset_piston_color">കളർ എഡിഷൻ</string>
+    <string name="dirac_headset_piston_standard">സ്റ്റാൻഡേർഡ് എഡിഷൻ</string>
+    <string name="dirac_headset_piston_youth">യൂത്ത് പതിപ്പ്</string>
+    <string name="dirac_headset_reduction_noise">Mi നോയ്സ് റദ്ദാക്കൽ ടൈപ്പ്-C</string>
+    <string name="dirac_headset_title">ഹെഡ്ഫോൺ ടൈപ്പ് തിരഞ്ഞെടുക്കുക</string>
+    <string name="dirac_title">Mi ശബ്ദ എൻഹാൻസർ</string>
+    <string name="dirac_preset_title">പ്രീസെറ്റ്</string>
+</resources>

--- a/parts/res/values-mr-rIN/strings.xml
+++ b/parts/res/values-mr-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ब्लूज</string>
+    <string name="dirac_preset_classical">क्लासिकल</string>
+    <string name="dirac_preset_country">कंट्री</string>
+    <string name="dirac_preset_dance">डान्स</string>
+    <string name="dirac_preset_electronic">इलेक्ट्रॉनिक</string>
+    <string name="dirac_default">डिफॉल्ट</string>
+    <string name="dirac_preset_jazz">जाझ</string>
+    <string name="dirac_preset_metal">मेटल</string>
+    <string name="dirac_preset_pop">पॉप</string>
+    <string name="dirac_preset_rock">रॉक</string>
+    <string name="dirac_headset_cancelling">Mi गोंगाट थांबवणे 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi कॅप्सूल</string>
+    <string name="dirac_headset_earbuds">Mi इअरबड्स</string>
+    <string name="dirac_headset_general">सामान्य</string>
+    <string name="dirac_headset_general_inear">सामान्य इन-इअर</string>
+    <string name="dirac_headset_half_in_ear">Mi हाल्फ इन-इयर</string>
+    <string name="dirac_headset_headphone">Mi हेडफोन्स</string>
+    <string name="dirac_headset_comfort">Mi कम्फर्ट</string>
+    <string name="dirac_headset_in_ear">Mi इन-इअर</string>
+    <string name="dirac_headset_in_ear2">कान 2 मध्ये Mi</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear(2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi इन इअर प्रो</string>
+    <string name="dirac_headset_piston_1">Mi पिस्टन-1</string>
+    <string name="dirac_headset_piston_2">Mi पिस्टन-2</string>
+    <string name="dirac_headset_piston_basic">मूळ अावृत्ती</string>
+    <string name="dirac_headset_piston_color">रंग आवृत्ति</string>
+    <string name="dirac_headset_piston_standard">मानक आवृत्ती</string>
+    <string name="dirac_headset_piston_youth">यूथ एडिशन</string>
+    <string name="dirac_headset_reduction_noise">Mi गोंगाट थांबवणे प्रकार-सी</string>
+    <string name="dirac_headset_title">हेडफोन प्रकार निवडा</string>
+    <string name="dirac_title">Mi ध्वनी वर्धक</string>
+    <string name="dirac_preset_title">प्रिसेट</string>
+</resources>

--- a/parts/res/values-ms-rMY/strings.xml
+++ b/parts/res/values-ms-rMY/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasik</string>
+    <string name="dirac_preset_country">Negara</string>
+    <string name="dirac_preset_dance">Tarian</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Lalai</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Pembatalan Bunyi Bising Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Bud telinga Mi</string>
+    <string name="dirac_headset_general">Umum</string>
+    <string name="dirac_headset_general_inear">In-Ear umum</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphone</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi di telinga</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Piston-2 Mi</string>
+    <string name="dirac_headset_piston_basic">Edisi asas</string>
+    <string name="dirac_headset_piston_color">Edisi Warna</string>
+    <string name="dirac_headset_piston_standard">Edisi biasa</string>
+    <string name="dirac_headset_piston_youth">Edisi Remaja</string>
+    <string name="dirac_headset_reduction_noise">Pembatalan Bunyi Bising Mi Type-C</string>
+    <string name="dirac_headset_title">Pilih jenis fon kepala</string>
+    <string name="dirac_title">Penambah Bunyi Mi</string>
+    <string name="dirac_preset_title">Pratetap</string>
+</resources>

--- a/parts/res/values-mt-rMT/strings.xml
+++ b/parts/res/values-mt-rMT/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassiku</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elettronika</string>
+    <string name="dirac_default">Komuni</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Ġenerali</string>
+    <string name="dirac_headset_general_inear">Ġenerali fil-Widna</string>
+    <string name="dirac_headset_half_in_ear">Mi Nofs fil-Widna</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">"Mi f'Widna 2"</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Edizzjoni Bażika</string>
+    <string name="dirac_headset_piston_color">Edizzjoni Kkulurita</string>
+    <string name="dirac_headset_piston_standard">Edizzjoni Standard</string>
+    <string name="dirac_headset_piston_youth">Edizzjoni Żagħżugħa</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Tip-C</string>
+    <string name="dirac_headset_title">"Agħżel it-tip ta' kuffji"</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Predeterminazzjoni</string>
+</resources>

--- a/parts/res/values-my-rMM/strings.xml
+++ b/parts/res/values-my-rMM/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ဘလူးစ်ဂီတ</string>
+    <string name="dirac_preset_classical">ဂန္ထဝင်ဂီတ</string>
+    <string name="dirac_preset_country">ကျေးလက်ဂီတ</string>
+    <string name="dirac_preset_dance">ဒန့်စ်</string>
+    <string name="dirac_preset_electronic">အီလက်ထရွန်နစ် ဂီတ</string>
+    <string name="dirac_default">ပုံသေ</string>
+    <string name="dirac_preset_jazz">ဂျတ်ဇ်ဂီတ</string>
+    <string name="dirac_preset_metal">မက်တယ်လ် ဂီတ</string>
+    <string name="dirac_preset_pop">ပေါ့ပ်</string>
+    <string name="dirac_preset_rock">ရော့ခ်</string>
+    <string name="dirac_headset_cancelling">Mi ဆူညံသံလျှော့ချခြင်း 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi နားကြပ်ပေါက်</string>
+    <string name="dirac_headset_general">အထွေထွေ</string>
+    <string name="dirac_headset_general_inear">နားတွင်းအထွေထွေ</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi နားကြပ်များ</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear နားကြပ်</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro နားကြပ်</string>
+    <string name="dirac_headset_piston_1">Mi ပစ်စတန်-1</string>
+    <string name="dirac_headset_piston_2">Mi ပစ်စတန်-2</string>
+    <string name="dirac_headset_piston_basic">အခြေခံ တည်းဖြတ်ချက်</string>
+    <string name="dirac_headset_piston_color">အရောင်တည်းဖြတ်မှု</string>
+    <string name="dirac_headset_piston_standard">စံ တည်းဖြတ်ချက်</string>
+    <string name="dirac_headset_piston_youth">လူငယ်နှင့်ဆိုင်သော</string>
+    <string name="dirac_headset_reduction_noise">Mi ဆူညံသံလျှော့ချခြင်း Type-C</string>
+    <string name="dirac_headset_title">နားကြပ်အမျိုးအစားရွေးချယ်ပါ</string>
+    <string name="dirac_title">Mi အသံကောင်းမွန်စေသူ</string>
+    <string name="dirac_preset_title">ကြိုသတ်မှတ်ခြင်း</string>
+</resources>

--- a/parts/res/values-nb/strings.xml
+++ b/parts/res/values-nb/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassisk</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronika</string>
+    <string name="dirac_default">Standard</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Støydempende 3,5 mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Vanlig</string>
+    <string name="dirac_headset_general_inear">Vanlig i-øret</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">Hovedutgave</string>
+    <string name="dirac_headset_piston_color">Fargeutgave</string>
+    <string name="dirac_headset_piston_standard">Standardutgave</string>
+    <string name="dirac_headset_piston_youth">Ungdomsutgave</string>
+    <string name="dirac_headset_reduction_noise">Mi Støydempende Type-C</string>
+    <string name="dirac_headset_title">Velg hodetelefontype</string>
+    <string name="dirac_title">Mi Lydforbedrer</string>
+    <string name="dirac_preset_title">Forhåndsinnstilling</string>
+</resources>

--- a/parts/res/values-ne-rIN/strings.xml
+++ b/parts/res/values-ne-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ब्लुज</string>
+    <string name="dirac_preset_classical">क्लासिकल</string>
+    <string name="dirac_preset_country">राष्ट्र</string>
+    <string name="dirac_preset_dance">नाच</string>
+    <string name="dirac_preset_electronic">इलेक्ट्रोनिक</string>
+    <string name="dirac_default">पूर्वनिर्धारित</string>
+    <string name="dirac_preset_jazz">ज्याज</string>
+    <string name="dirac_preset_metal">मेटल</string>
+    <string name="dirac_preset_pop">पप</string>
+    <string name="dirac_preset_rock">रक</string>
+    <string name="dirac_headset_cancelling">Mi हल्ला रद्द गर्दै 3.5मि. मि</string>
+    <string name="dirac_headset_capsule">Mi क्यापसुल</string>
+    <string name="dirac_headset_earbuds">Mi इयरबड्स</string>
+    <string name="dirac_headset_general">साधारण</string>
+    <string name="dirac_headset_general_inear">सामान्य कान-मा</string>
+    <string name="dirac_headset_half_in_ear">Mi हाल्फ इन ईयर</string>
+    <string name="dirac_headset_headphone">Mi हेडफोनहरू</string>
+    <string name="dirac_headset_comfort">Mi सुविधा</string>
+    <string name="dirac_headset_in_ear">Mi कान-मा</string>
+    <string name="dirac_headset_in_ear2">Mi इन-ईयर 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi इन-ईयर (2०1३)</string>
+    <string name="dirac_headset_in_ear_pro">Mi कान-मा प्रो</string>
+    <string name="dirac_headset_piston_1">Mi पिस्टन-1</string>
+    <string name="dirac_headset_piston_2">Mi पिस्टन-2</string>
+    <string name="dirac_headset_piston_basic">मूल संस्करण</string>
+    <string name="dirac_headset_piston_color">रङ संस्करण</string>
+    <string name="dirac_headset_piston_standard">मानक संस्करण</string>
+    <string name="dirac_headset_piston_youth">युवा संस्करण</string>
+    <string name="dirac_headset_reduction_noise">Mi हल्ला रद्द गर्दै प्रकार-C</string>
+    <string name="dirac_headset_title">हेडफोन प्रकार छनोट गर्नुहोस्</string>
+    <string name="dirac_title">Mi आवाज एन्हान्सर</string>
+    <string name="dirac_preset_title">प्रिसेट</string>
+</resources>

--- a/parts/res/values-ne-rNP/strings.xml
+++ b/parts/res/values-ne-rNP/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ब्लुज</string>
+    <string name="dirac_preset_classical">क्लासिकल</string>
+    <string name="dirac_preset_country">राष्ट्र</string>
+    <string name="dirac_preset_dance">नाच</string>
+    <string name="dirac_preset_electronic">इलेक्ट्रोनिक</string>
+    <string name="dirac_default">पूर्वनिर्धारित</string>
+    <string name="dirac_preset_jazz">ज्याज</string>
+    <string name="dirac_preset_metal">मेटल</string>
+    <string name="dirac_preset_pop">पप</string>
+    <string name="dirac_preset_rock">रक</string>
+    <string name="dirac_headset_cancelling">Mi हल्ला रद्द गर्दै 3.5मि. मि</string>
+    <string name="dirac_headset_capsule">Mi क्यापसुल</string>
+    <string name="dirac_headset_earbuds">Mi इयरबड्स</string>
+    <string name="dirac_headset_general">साधारण</string>
+    <string name="dirac_headset_general_inear">सामान्य कान-मा</string>
+    <string name="dirac_headset_half_in_ear">Mi हाल्फ इन ईयर</string>
+    <string name="dirac_headset_headphone">Mi हेडफोनहरू</string>
+    <string name="dirac_headset_comfort">Mi सुविधा</string>
+    <string name="dirac_headset_in_ear">Mi कान-मा</string>
+    <string name="dirac_headset_in_ear2">Mi इन-ईयर 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi इन-ईयर (2०1३)</string>
+    <string name="dirac_headset_in_ear_pro">Mi कान-मा प्रो</string>
+    <string name="dirac_headset_piston_1">Mi पिस्टन-1</string>
+    <string name="dirac_headset_piston_2">Mi पिस्टन-2</string>
+    <string name="dirac_headset_piston_basic">मूल संस्करण</string>
+    <string name="dirac_headset_piston_color">रङ संस्करण</string>
+    <string name="dirac_headset_piston_standard">मानक संस्करण</string>
+    <string name="dirac_headset_piston_youth">युवा संस्करण</string>
+    <string name="dirac_headset_reduction_noise">Mi हल्ला रद्द गर्दै प्रकार-C</string>
+    <string name="dirac_headset_title">हेडफोन प्रकार छनोट गर्नुहोस्</string>
+    <string name="dirac_title">Mi आवाज एन्हान्सर</string>
+    <string name="dirac_preset_title">प्रिसेट</string>
+</resources>

--- a/parts/res/values-nl/strings.xml
+++ b/parts/res/values-nl/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassiek</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronisch</string>
+    <string name="dirac_default">Standaard</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise annuleren 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi oordoppen</string>
+    <string name="dirac_headset_general">Algemeen</string>
+    <string name="dirac_headset_general_inear">Algemene in-ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basis editie</string>
+    <string name="dirac_headset_piston_color">Kleur editie</string>
+    <string name="dirac_headset_piston_standard">Standaard editie</string>
+    <string name="dirac_headset_piston_youth">Jeugdeditie</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise annuleren Type-C</string>
+    <string name="dirac_headset_title">Kies type hoofdtelefoon</string>
+    <string name="dirac_title">Mi Geluid Verbeteraar</string>
+    <string name="dirac_preset_title">Preset</string>
+</resources>

--- a/parts/res/values-or-rIN/strings.xml
+++ b/parts/res/values-or-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ବ୍ଲୁଜ୍</string>
+    <string name="dirac_preset_classical">ଶାସ୍ତ୍ରୀୟ</string>
+    <string name="dirac_preset_country">କଣ୍ଟ୍ରୀ</string>
+    <string name="dirac_preset_dance">ନୃତ୍ୟ</string>
+    <string name="dirac_preset_electronic">ଇଲେକ୍ଟ୍ରୋନିକ୍</string>
+    <string name="dirac_default">ଡିଫଲ୍ଟ୍‌</string>
+    <string name="dirac_preset_jazz">ଜାଜ୍</string>
+    <string name="dirac_preset_metal">ମେଟାଲ୍</string>
+    <string name="dirac_preset_pop">ପପ୍‌</string>
+    <string name="dirac_preset_rock">ରକ୍</string>
+    <string name="dirac_headset_cancelling">Mi ଶବ୍ଦ ପ୍ରଦୂଷଣ ବାତିଲ କରୁଛି 3.5 mm</string>
+    <string name="dirac_headset_capsule">Mi କ୍ୟାପସୁଲ୍</string>
+    <string name="dirac_headset_earbuds">Mi ଇଅର୍‌ବଡ୍</string>
+    <string name="dirac_headset_general">ସାଧାରଣ</string>
+    <string name="dirac_headset_general_inear">ସାଧାରଣ ଇନ୍‍-ଇଅର୍‍</string>
+    <string name="dirac_headset_half_in_ear">Mi ହାଫ ଇନ-ଇଅର</string>
+    <string name="dirac_headset_headphone">Mi ହେଡ୍‌ଫୋନ୍</string>
+    <string name="dirac_headset_comfort">Mi କମ୍ଫର୍ଟ</string>
+    <string name="dirac_headset_in_ear">Mi ଇନ୍‌‍-ଇଅର୍‍</string>
+    <string name="dirac_headset_in_ear2">Mi ଇନ୍-ଇୟର 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ଇନ୍-ଇୟର(2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ଇନ୍‌‍-ଇଅର୍‌ ପ୍ରୋ</string>
+    <string name="dirac_headset_piston_1">Mi ପିଷ୍ଟନ୍‍-1</string>
+    <string name="dirac_headset_piston_2">Mi ପିଷ୍ଟନ୍‍-2</string>
+    <string name="dirac_headset_piston_basic">ମୂଳ ସଂସ୍କରଣ</string>
+    <string name="dirac_headset_piston_color">ରଙ୍ଗ ସଂସ୍କରଣ</string>
+    <string name="dirac_headset_piston_standard">ମାନକ ସଂସ୍କରଣ</string>
+    <string name="dirac_headset_piston_youth">ଯୁବ ସଂସ୍କରଣ</string>
+    <string name="dirac_headset_reduction_noise">Mi ଶବ୍ଦ ପ୍ରଦୂଷଣ ବାତିଲ କରାଯାଉଛି C- ପ୍ରକାରର</string>
+    <string name="dirac_headset_title">ହେଡ୍‌ଫୋନ୍‌ ପ୍ରକାର ଚୟନ କରନ୍ତୁ</string>
+    <string name="dirac_title">Mi ଧ୍ୱନୀ ବର୍ଦ୍ଧକ</string>
+    <string name="dirac_preset_title">ପ୍ରିସେଟ୍‌</string>
+</resources>

--- a/parts/res/values-pa-rIN/strings.xml
+++ b/parts/res/values-pa-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ਬਲੂਜ਼</string>
+    <string name="dirac_preset_classical">ਸ਼ਾਸਤਰੀ</string>
+    <string name="dirac_preset_country">ਦੇਸ਼</string>
+    <string name="dirac_preset_dance">ਡਾਂਸ</string>
+    <string name="dirac_preset_electronic">ਇਲੈਕਟ੍ਰੋਨਿਕ</string>
+    <string name="dirac_default">ਪੂਰਵ-ਨਿਰਧਾਰਤ</string>
+    <string name="dirac_preset_jazz">ਜੈਜ਼</string>
+    <string name="dirac_preset_metal">ਮੈਟਲ</string>
+    <string name="dirac_preset_pop">ਪੌਪ</string>
+    <string name="dirac_preset_rock">ਰੌਕ</string>
+    <string name="dirac_headset_cancelling">Mi ਸ਼ੋਰ ਰੱਦ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ 3.5ਮਿ.ਮਿ.</string>
+    <string name="dirac_headset_capsule">Mi ਕੈਪਸੂਲ</string>
+    <string name="dirac_headset_earbuds">Mi ਈਅਰਬਡਸ</string>
+    <string name="dirac_headset_general">ਸਧਾਰਨ</string>
+    <string name="dirac_headset_general_inear">ਸਧਾਰਨ ਇਨ-ਈਅਰ</string>
+    <string name="dirac_headset_half_in_ear">Mi ਹਾਫ਼ ਇਨ ਈਅਰ</string>
+    <string name="dirac_headset_headphone">Mi ਹੈੱਡਫ਼ੋਨਸ</string>
+    <string name="dirac_headset_comfort">Mi ਕਮਫ਼ਰਟ</string>
+    <string name="dirac_headset_in_ear">Mi ਇਨ-ਈਅਰ</string>
+    <string name="dirac_headset_in_ear2">Mi ਇਨ-ਈਅਰ 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ਇਨ-ਈਅਰ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ਇਨ-ਈਅਰ ਪ੍ਰੋ</string>
+    <string name="dirac_headset_piston_1">Mi ਪਿਸਟਨ-1</string>
+    <string name="dirac_headset_piston_2">Mi ਪਿਸਟਨ-2</string>
+    <string name="dirac_headset_piston_basic">ਮੂਲ ਸੰਸਕਰਨ</string>
+    <string name="dirac_headset_piston_color">ਰੰਗ ਸੰਸਕਰਨ</string>
+    <string name="dirac_headset_piston_standard">ਸਟੈਂਡਰਡ ਸੰਸਕਰਨ</string>
+    <string name="dirac_headset_piston_youth">ਯੂਥ ਸੰਸਕਰਨ</string>
+    <string name="dirac_headset_reduction_noise">Mi ਸ਼ੋਰ ਰੱਦ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ ਕਿਸਮ-C</string>
+    <string name="dirac_headset_title">ਹੈੱਡਫ਼ੋਨਾਂ ਦੀ ਕਿਸਮ ਚੁਣੋ</string>
+    <string name="dirac_title">Mi ਧੁਨੀ ਵਰਧਕ</string>
+    <string name="dirac_preset_title">ਪ੍ਰੀਸੈੱਟ</string>
+</resources>

--- a/parts/res/values-pl/strings.xml
+++ b/parts/res/values-pl/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Muzyka poważna</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektroniczna</string>
+    <string name="dirac_default">Domyślny</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi z redukcją szumów (3.5mm)</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Douszne Mi</string>
+    <string name="dirac_headset_general">Douszne</string>
+    <string name="dirac_headset_general_inear">Dokanałowe</string>
+    <string name="dirac_headset_half_in_ear">Mi częściowo dokanałowe</string>
+    <string name="dirac_headset_headphone">Słuchawki Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi Dokanałowe</string>
+    <string name="dirac_headset_in_ear2">Mi dokanałowe 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi dokanałowe (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi Dokanałowe Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston v1</string>
+    <string name="dirac_headset_piston_2">Mi Piston v2</string>
+    <string name="dirac_headset_piston_basic">Mi Piston Basic</string>
+    <string name="dirac_headset_piston_color">Edycja kolorowa</string>
+    <string name="dirac_headset_piston_standard">Standardowa edycja</string>
+    <string name="dirac_headset_piston_youth">Edycja młodzieżowa</string>
+    <string name="dirac_headset_reduction_noise">Mi z redukcją szumów (Typ-C)</string>
+    <string name="dirac_headset_title">Typ słuchawek</string>
+    <string name="dirac_title">Ulepszanie dźwięku Mi</string>
+    <string name="dirac_preset_title">Profil</string>
+</resources>

--- a/parts/res/values-pt-rBR/strings.xml
+++ b/parts/res/values-pt-rBR/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clássica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Eletrônica</string>
+    <string name="dirac_default">Padrão</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Genérico</string>
+    <string name="dirac_headset_general_inear">In-Ear genérico</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston 1</string>
+    <string name="dirac_headset_piston_2">Mi Piston 2</string>
+    <string name="dirac_headset_piston_basic">Edição Básica</string>
+    <string name="dirac_headset_piston_color">Edição Color</string>
+    <string name="dirac_headset_piston_standard">Edição Padrão</string>
+    <string name="dirac_headset_piston_youth">Edição Youth</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Tipo-C</string>
+    <string name="dirac_headset_title">Escolher tipo de fone de ouvido</string>
+    <string name="dirac_title">Amplificador Mi Sound</string>
+    <string name="dirac_preset_title">Predefinição</string>
+</resources>

--- a/parts/res/values-pt-rPT/strings.xml
+++ b/parts/res/values-pt-rPT/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clássica</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Eletrónica</string>
+    <string name="dirac_default">Predefinido</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling (3.5mm)</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Genéricos</string>
+    <string name="dirac_headset_general_inear">Genéricos In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston 1</string>
+    <string name="dirac_headset_piston_2">Mi Piston 2</string>
+    <string name="dirac_headset_piston_basic">Edição básica</string>
+    <string name="dirac_headset_piston_color">Edição Color</string>
+    <string name="dirac_headset_piston_standard">Edição Padrão</string>
+    <string name="dirac_headset_piston_youth">Edição Youth</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling (USB-C)</string>
+    <string name="dirac_headset_title">Escolher tipo de auricular</string>
+    <string name="dirac_title">Amplificador Mi Sound</string>
+    <string name="dirac_preset_title">Predefinição</string>
+</resources>

--- a/parts/res/values-ro/strings.xml
+++ b/parts/res/values-ro/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Clasic</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Electronic</string>
+    <string name="dirac_default">Implicit</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Se anulează Zgomotul Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Căşti în ureche Mi</string>
+    <string name="dirac_headset_general">General</string>
+    <string name="dirac_headset_general_inear">General în ureche</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Căşti Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi în ureche</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Căști în ureche Mi (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Ediție de bază</string>
+    <string name="dirac_headset_piston_color">Ediție Color</string>
+    <string name="dirac_headset_piston_standard">Ediție standard</string>
+    <string name="dirac_headset_piston_youth">Ediție Youth</string>
+    <string name="dirac_headset_reduction_noise">Se anulează Zgomotul Mi Type C</string>
+    <string name="dirac_headset_title">Alege tipul de căști</string>
+    <string name="dirac_title">Mi Sound Amplificator</string>
+    <string name="dirac_preset_title">Presetare</string>
+</resources>

--- a/parts/res/values-ru/strings.xml
+++ b/parts/res/values-ru/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блюз</string>
+    <string name="dirac_preset_classical">Классическая</string>
+    <string name="dirac_preset_country">Кантри</string>
+    <string name="dirac_preset_dance">Танцевальная</string>
+    <string name="dirac_preset_electronic">Электронная</string>
+    <string name="dirac_default">По умолчанию</string>
+    <string name="dirac_preset_jazz">Джаз</string>
+    <string name="dirac_preset_metal">Металл</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5 мм</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Обычные наушники</string>
+    <string name="dirac_headset_general_inear">Обычные внутриканальные</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Mi Piston Basic</string>
+    <string name="dirac_headset_piston_color">Mi Piston Colorful</string>
+    <string name="dirac_headset_piston_standard">Mi Piston Standard</string>
+    <string name="dirac_headset_piston_youth">Mi Piston Youth</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Тип наушников</string>
+    <string name="dirac_title">Улучшение звука Mi</string>
+    <string name="dirac_preset_title">Настройка</string>
+</resources>

--- a/parts/res/values-sk/strings.xml
+++ b/parts/res/values-sk/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasika</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronika</string>
+    <string name="dirac_default">Predvolené</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Rušenie hluku 3,5mm</string>
+    <string name="dirac_headset_capsule">Púzdro Mi</string>
+    <string name="dirac_headset_earbuds">Xiaomi slúchadlá</string>
+    <string name="dirac_headset_general">Obyčajné</string>
+    <string name="dirac_headset_general_inear">Bežné špunty</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Slúchadlá</string>
+    <string name="dirac_headset_comfort">Mi Komfort</string>
+    <string name="dirac_headset_in_ear">Xiaomi špunty</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (Mi v uchu) (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Xiaomi Piston-1</string>
+    <string name="dirac_headset_piston_2">Xiaomi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Základné</string>
+    <string name="dirac_headset_piston_color">Farebná edícia</string>
+    <string name="dirac_headset_piston_standard">Xiaomi Piston-3</string>
+    <string name="dirac_headset_piston_youth">Xiaomi Youth</string>
+    <string name="dirac_headset_reduction_noise">Mi Rušenie hluku Typ C</string>
+    <string name="dirac_headset_title">Typ slúchadiel</string>
+    <string name="dirac_title">Vylepšenie Mi Sound</string>
+    <string name="dirac_preset_title">Predvoľba</string>
+</resources>

--- a/parts/res/values-sl/strings.xml
+++ b/parts/res/values-sl/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasika</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dance</string>
+    <string name="dirac_preset_electronic">Elektronska</string>
+    <string name="dirac_default">Privzeto</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Odvzem hrupa 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Splošno</string>
+    <string name="dirac_headset_general_inear">Splošne In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi slušalke</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Basic Edition</string>
+    <string name="dirac_headset_piston_color">Barvna Izdaja</string>
+    <string name="dirac_headset_piston_standard">Standard Edition</string>
+    <string name="dirac_headset_piston_youth">Youth Edition</string>
+    <string name="dirac_headset_reduction_noise">Mi Odvzem hrupa Type-C</string>
+    <string name="dirac_headset_title">Določi tip slušalk</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Prednastavitve</string>
+</resources>

--- a/parts/res/values-sq-rAL/strings.xml
+++ b/parts/res/values-sq-rAL/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Bluz</string>
+    <string name="dirac_preset_classical">Klasike</string>
+    <string name="dirac_preset_country">Shteti</string>
+    <string name="dirac_preset_dance">Vallëzim</string>
+    <string name="dirac_preset_electronic">Elektronike</string>
+    <string name="dirac_default">Paracaktuar</string>
+    <string name="dirac_preset_jazz">Xhaz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rok</string>
+    <string name="dirac_headset_cancelling">Mi anulim zhurme 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi kapsula</string>
+    <string name="dirac_headset_earbuds">Mi kufje të vogla</string>
+    <string name="dirac_headset_general">Përgjithshëm</string>
+    <string name="dirac_headset_general_inear">Përgjithshëm në vesh</string>
+    <string name="dirac_headset_half_in_ear">Mi Half në vesh</string>
+    <string name="dirac_headset_headphone">Mi kufje</string>
+    <string name="dirac_headset_comfort">Mi komoditet</string>
+    <string name="dirac_headset_in_ear">Mi kufje në vesh</string>
+    <string name="dirac_headset_in_ear2">Mi në vesh 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi në vesh (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi kufje në vesh Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Varianti themelor</string>
+    <string name="dirac_headset_piston_color">Varianti me ngjyra</string>
+    <string name="dirac_headset_piston_standard">Varianti standard</string>
+    <string name="dirac_headset_piston_youth">Varianti për të rinj</string>
+    <string name="dirac_headset_reduction_noise">Mi anulim zhurme Tipi-C</string>
+    <string name="dirac_headset_title">Zgjidh tipin e kufjeve</string>
+    <string name="dirac_title">Përmirësues zëri Mi</string>
+    <string name="dirac_preset_title">Paracilëso</string>
+</resources>

--- a/parts/res/values-sr/strings.xml
+++ b/parts/res/values-sr/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блуз</string>
+    <string name="dirac_preset_classical">Класика</string>
+    <string name="dirac_preset_country">Кантри</string>
+    <string name="dirac_preset_dance">Денс</string>
+    <string name="dirac_preset_electronic">Електро</string>
+    <string name="dirac_default">Задато</string>
+    <string name="dirac_preset_jazz">Џез</string>
+    <string name="dirac_preset_metal">Метал</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">Опште</string>
+    <string name="dirac_headset_general_inear">Опште In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Слушалице</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Основно издање</string>
+    <string name="dirac_headset_piston_color">Издање у боји</string>
+    <string name="dirac_headset_piston_standard">Стандардно издање</string>
+    <string name="dirac_headset_piston_youth">Издање за младе</string>
+    <string name="dirac_headset_reduction_noise">Mi Noise Cancelling Type-C</string>
+    <string name="dirac_headset_title">Изаберите тип слушалица</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_preset_title">Поставке</string>
+</resources>

--- a/parts/res/values-sv/strings.xml
+++ b/parts/res/values-sv/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klassisk</string>
+    <string name="dirac_preset_country">Country</string>
+    <string name="dirac_preset_dance">Dansa</string>
+    <string name="dirac_preset_electronic">Elektroniskt</string>
+    <string name="dirac_default">Standard</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metall</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Brusreducering 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Hörlurar</string>
+    <string name="dirac_headset_general">Allmänt</string>
+    <string name="dirac_headset_general_inear">Allmänna In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Hörlurar</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Grundläggande upplaga</string>
+    <string name="dirac_headset_piston_color">Färgad upplaga</string>
+    <string name="dirac_headset_piston_standard">Standardupplaga</string>
+    <string name="dirac_headset_piston_youth">Ungdomlig upplaga</string>
+    <string name="dirac_headset_reduction_noise">Mi Brusreducering Type-C</string>
+    <string name="dirac_headset_title">Välj hörlurstyper</string>
+    <string name="dirac_title">Mi ljudförstärkare</string>
+    <string name="dirac_preset_title">Förinställa</string>
+</resources>

--- a/parts/res/values-ta-rIN/strings.xml
+++ b/parts/res/values-ta-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">ப்ளூஸ்</string>
+    <string name="dirac_preset_classical">கிளாசிக்கல்</string>
+    <string name="dirac_preset_country">கண்ட்ரி</string>
+    <string name="dirac_preset_dance">நடனம்</string>
+    <string name="dirac_preset_electronic">எலக்ட்ரானிக்</string>
+    <string name="dirac_default">இயல்புநிலை</string>
+    <string name="dirac_preset_jazz">ஜாஸ்</string>
+    <string name="dirac_preset_metal">மெட்டல்</string>
+    <string name="dirac_preset_pop">பாப்</string>
+    <string name="dirac_preset_rock">ராக்</string>
+    <string name="dirac_headset_cancelling">Mi இரைச்சல் குறைப்பு 3.5மிமீ</string>
+    <string name="dirac_headset_capsule">Mi கேப்ஸ்யூல்</string>
+    <string name="dirac_headset_earbuds">Mi earbuds</string>
+    <string name="dirac_headset_general">பொது</string>
+    <string name="dirac_headset_general_inear">பொதுவான இன்-இயர்</string>
+    <string name="dirac_headset_half_in_ear">Mi ஹாஃப் இன்-இயர்</string>
+    <string name="dirac_headset_headphone">Mi ஹெட்ஃபோன்கள்</string>
+    <string name="dirac_headset_comfort">Mi வசதி</string>
+    <string name="dirac_headset_in_ear">Mi இன்-இயர்</string>
+    <string name="dirac_headset_in_ear2">Mi இன்-இயர் 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi இன்-இயர்(2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi இன்-இயர் ப்ரோ</string>
+    <string name="dirac_headset_piston_1">Mi பிஸ்டன்-1</string>
+    <string name="dirac_headset_piston_2">Mi பிஸ்டன்-2</string>
+    <string name="dirac_headset_piston_basic">அடிப்படை பதிப்பு</string>
+    <string name="dirac_headset_piston_color">கலர் பதிப்பு</string>
+    <string name="dirac_headset_piston_standard">இயல்பு பதிப்பு</string>
+    <string name="dirac_headset_piston_youth">யூத் எடிஷன்</string>
+    <string name="dirac_headset_reduction_noise">Mi இரைச்சல் குறைப்பு Type-C</string>
+    <string name="dirac_headset_title">ஹெட்ஃபோன் வகையைத் தேர்வுசெய்யவும்</string>
+    <string name="dirac_title">Mi சவுண்ட் என்ஹேன்சர்</string>
+    <string name="dirac_preset_title">முன்னமைவு</string>
+</resources>

--- a/parts/res/values-te-rIN/strings.xml
+++ b/parts/res/values-te-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">బ్లూస్</string>
+    <string name="dirac_preset_classical">సాంప్రదాయ</string>
+    <string name="dirac_preset_country">కంట్రీ</string>
+    <string name="dirac_preset_dance">నృత్యం</string>
+    <string name="dirac_preset_electronic">ఎలక్ట్రానిక్</string>
+    <string name="dirac_default">డిఫాల్ట్</string>
+    <string name="dirac_preset_jazz">జాజ్</string>
+    <string name="dirac_preset_metal">మెటల్</string>
+    <string name="dirac_preset_pop">పాప్</string>
+    <string name="dirac_preset_rock">రాక్</string>
+    <string name="dirac_headset_cancelling">Mi రొద తగ్గింపు 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi క్యాప్స్యూల్</string>
+    <string name="dirac_headset_earbuds">Mi ఇయర్ బడ్స్</string>
+    <string name="dirac_headset_general">సాధారణం</string>
+    <string name="dirac_headset_general_inear">సాధారణ ఇన్-ఇయర్</string>
+    <string name="dirac_headset_half_in_ear">Mi హాఫ్ ఇన్ ఇయర్</string>
+    <string name="dirac_headset_headphone">Mi హెడ్‌ఫోన్స్</string>
+    <string name="dirac_headset_comfort">Mi కంఫర్ట్</string>
+    <string name="dirac_headset_in_ear">Mi ఇన్-ఇయర్</string>
+    <string name="dirac_headset_in_ear2">Mi ఇన్-ఇయర్ 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ఇన్-ఇయర్ (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ఇన్-ఇయర్ ప్రో</string>
+    <string name="dirac_headset_piston_1">Mi పిస్టన్-1</string>
+    <string name="dirac_headset_piston_2">Mi పిస్టన్-2</string>
+    <string name="dirac_headset_piston_basic">బేసిక్ ఎడిషన్</string>
+    <string name="dirac_headset_piston_color">రంగుల ఎడిషన్</string>
+    <string name="dirac_headset_piston_standard">ప్రామాణిక ఎడిషన్</string>
+    <string name="dirac_headset_piston_youth">యూత్ ఎడిషన్</string>
+    <string name="dirac_headset_reduction_noise">Mi రొద తగ్గింపు టైప్-C</string>
+    <string name="dirac_headset_title">హెడ్‌ఫోన్‌ల రకాన్ని ఎంచుకోండి</string>
+    <string name="dirac_title">Mi శబ్ద మెరుగుదల సాధనం</string>
+    <string name="dirac_preset_title">పూర్వ అమరిక</string>
+</resources>

--- a/parts/res/values-th/strings.xml
+++ b/parts/res/values-th/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">บลูส์</string>
+    <string name="dirac_preset_classical">คลาสสิค</string>
+    <string name="dirac_preset_country">คันทรี่</string>
+    <string name="dirac_preset_dance">แด๊นซ์</string>
+    <string name="dirac_preset_electronic">อิเล็กทรอนิกส์</string>
+    <string name="dirac_default">ค่าเริ่มต้น</string>
+    <string name="dirac_preset_jazz">แจ๊ส</string>
+    <string name="dirac_preset_metal">เมทัล</string>
+    <string name="dirac_preset_pop">ป๊อป</string>
+    <string name="dirac_preset_rock">ร็อค</string>
+    <string name="dirac_headset_cancelling">Mi ลดเสียงรบกวน 3.5mm</string>
+    <string name="dirac_headset_capsule">แคปซูล Mi</string>
+    <string name="dirac_headset_earbuds">Mi Earbuds</string>
+    <string name="dirac_headset_general">ทั่วไป</string>
+    <string name="dirac_headset_general_inear">หูฟังทั่วไปแบบ In-Ear</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi เฮดโฟน</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">หูฟังรุ่นธรรมดา</string>
+    <string name="dirac_headset_piston_color">หูฟังรุ่นหลากสี</string>
+    <string name="dirac_headset_piston_standard">หูฟังรุ่นมาตรฐาน</string>
+    <string name="dirac_headset_piston_youth">หูฟังรุ่น Youth</string>
+    <string name="dirac_headset_reduction_noise">Mi ลดเสียงรบกวน Type-C</string>
+    <string name="dirac_headset_title">เลือกประเภทของหูฟัง</string>
+    <string name="dirac_title">ตัวเพิ่มประสิทธิภาพเสียง Mi</string>
+    <string name="dirac_preset_title">ค่าที่ตั้งไว้</string>
+</resources>

--- a/parts/res/values-tr/strings.xml
+++ b/parts/res/values-tr/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blues</string>
+    <string name="dirac_preset_classical">Klasik</string>
+    <string name="dirac_preset_country">Yerel</string>
+    <string name="dirac_preset_dance">Dans</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Varsayılan</string>
+    <string name="dirac_preset_jazz">Caz</string>
+    <string name="dirac_preset_metal">Metal</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Mi Gürültü Engelleme 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Kapsül</string>
+    <string name="dirac_headset_earbuds">Mi Kulaklıkları</string>
+    <string name="dirac_headset_general">Genel</string>
+    <string name="dirac_headset_general_inear">Genel Kulak-İçi</string>
+    <string name="dirac_headset_half_in_ear">Mi Yarı Kulak-İçi</string>
+    <string name="dirac_headset_headphone">Mi kulaklıkları</string>
+    <string name="dirac_headset_comfort">Mi Konfor</string>
+    <string name="dirac_headset_in_ear">Mi Kulak-İçi</string>
+    <string name="dirac_headset_in_ear2">Mi Kulak-İçi 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi Kulak-İçi (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi Kulak-İçi Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Piston-2</string>
+    <string name="dirac_headset_piston_basic">Temel sürüm</string>
+    <string name="dirac_headset_piston_color">Renkli Sürüm</string>
+    <string name="dirac_headset_piston_standard">Standart sürüm</string>
+    <string name="dirac_headset_piston_youth">Gençlik sürümü</string>
+    <string name="dirac_headset_reduction_noise">Mi Gürültü Engelleme Type-C</string>
+    <string name="dirac_headset_title">Kulaklık türünü seçin</string>
+    <string name="dirac_title">Mi Ses Yükseltici</string>
+    <string name="dirac_preset_title">Ön ayarlar</string>
+</resources>

--- a/parts/res/values-ug-rCN/strings.xml
+++ b/parts/res/values-ug-rCN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">برۇس</string>
+    <string name="dirac_preset_classical">كىلاسسىك</string>
+    <string name="dirac_preset_country">يېزا</string>
+    <string name="dirac_preset_dance">ئۇسۇل مۇزىكىسى</string>
+    <string name="dirac_preset_electronic">ئېلېكتىرۇنلۇق</string>
+    <string name="dirac_default">يوق</string>
+    <string name="dirac_preset_jazz">جاز</string>
+    <string name="dirac_preset_metal">مېتال</string>
+    <string name="dirac_preset_pop">مودا</string>
+    <string name="dirac_preset_rock">روك</string>
+    <string name="dirac_headset_cancelling">شياۋمى شاۋقۇن تۆۋەنلىتىش3.5mm</string>
+    <string name="dirac_headset_capsule">شياۋمى كاپسۇلى</string>
+    <string name="dirac_headset_earbuds">قۇلاققا كەيدۈرۈش شەكىللىك</string>
+    <string name="dirac_headset_general">ئورتاق</string>
+    <string name="dirac_headset_general_inear">ئورتاق قۇلاققا سېلىش شەكىللىك</string>
+    <string name="dirac_headset_half_in_ear">قۇلاققا يېرىم كىرىدىغان تىڭشىغۇچ</string>
+    <string name="dirac_headset_headphone">شياۋمى بېشىغا كىيىش شەكىللىك</string>
+    <string name="dirac_headset_comfort">شىياۋمى قولاي نەشرى</string>
+    <string name="dirac_headset_in_ear">شياۋمى چەمبىرەك</string>
+    <string name="dirac_headset_in_ear2">شياۋمى چەمبىرەك2</string>
+    <string name="dirac_headset_in_ear_2013">قۇلاققا سېلىش شەكىللىك</string>
+    <string name="dirac_headset_in_ear_pro">شياۋمى چەمبىرەكPro</string>
+    <string name="dirac_headset_piston_1">شياۋمى پورشېن1</string>
+    <string name="dirac_headset_piston_2">شياۋمى پورشېن1</string>
+    <string name="dirac_headset_piston_basic">شياۋمى پورشېن ئاددى نەشرى</string>
+    <string name="dirac_headset_piston_color">شياۋمى پورشېن رەڭگارەڭ نۇسخىسى</string>
+    <string name="dirac_headset_piston_standard">شياۋمى پورشېن ئۆلچەملىك نەشرى</string>
+    <string name="dirac_headset_piston_youth">شياۋمى پورشېن ياشلار نەشرى</string>
+    <string name="dirac_headset_reduction_noise">شياۋمى شاۋقۇن چۈشۈرگۈچ typeC</string>
+    <string name="dirac_headset_title">تىڭشىغۇچ تەڭشىكى</string>
+    <string name="dirac_title">مى ئاۋاز ئاۋاز سۈپىتىنى كۆتۈرگۈچنى ئىشلىتىش</string>
+    <string name="dirac_preset_title">ئاڭلاش سېزىمى</string>
+</resources>

--- a/parts/res/values-uk/strings.xml
+++ b/parts/res/values-uk/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Блюз</string>
+    <string name="dirac_preset_classical">Класика</string>
+    <string name="dirac_preset_country">Кантрі</string>
+    <string name="dirac_preset_dance">Танцювальна</string>
+    <string name="dirac_preset_electronic">Електро</string>
+    <string name="dirac_default">За замовчуванням</string>
+    <string name="dirac_preset_jazz">Джаз</string>
+    <string name="dirac_preset_metal">Метал</string>
+    <string name="dirac_preset_pop">Поп</string>
+    <string name="dirac_preset_rock">Рок</string>
+    <string name="dirac_headset_cancelling">Mi Noise Cancelling 3.5 мм</string>
+    <string name="dirac_headset_capsule">Mi Капсула</string>
+    <string name="dirac_headset_earbuds">Навушники Xiaomi</string>
+    <string name="dirac_headset_general">Звичайні навушники</string>
+    <string name="dirac_headset_general_inear">Звичайні вкладиші</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Headphones</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi вкладиші</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi пістони-1</string>
+    <string name="dirac_headset_piston_2">Xiaomi пістони-2</string>
+    <string name="dirac_headset_piston_basic">Звичайні пістони</string>
+    <string name="dirac_headset_piston_color">Кольорова версія</string>
+    <string name="dirac_headset_piston_standard">Стандартна версія</string>
+    <string name="dirac_headset_piston_youth">Молодіжна версія</string>
+    <string name="dirac_headset_reduction_noise">Mi ANC Type-C</string>
+    <string name="dirac_headset_title">Тип навушників</string>
+    <string name="dirac_title">Покращення звуку \"Мі Sound\"</string>
+    <string name="dirac_preset_title">Налаштування</string>
+</resources>

--- a/parts/res/values-ur-rIN/strings.xml
+++ b/parts/res/values-ur-rIN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">بلیوز</string>
+    <string name="dirac_preset_classical">کلاسیکی</string>
+    <string name="dirac_preset_country">ملک</string>
+    <string name="dirac_preset_dance">رقص</string>
+    <string name="dirac_preset_electronic">الیکٹرونک</string>
+    <string name="dirac_default">ڈیفالٹ</string>
+    <string name="dirac_preset_jazz">جاز</string>
+    <string name="dirac_preset_metal">دھات</string>
+    <string name="dirac_preset_pop">پاپ</string>
+    <string name="dirac_preset_rock">راک</string>
+    <string name="dirac_headset_cancelling">Mi شور منسوخی 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi کیپسول</string>
+    <string name="dirac_headset_earbuds">Mi ایربڈز</string>
+    <string name="dirac_headset_general">عمومی</string>
+    <string name="dirac_headset_general_inear">عمومی ان-ایر</string>
+    <string name="dirac_headset_half_in_ear">Mi ہاف ان ایئر</string>
+    <string name="dirac_headset_headphone">Mi ہیڈ فونز</string>
+    <string name="dirac_headset_comfort">Mi کمفرٹ</string>
+    <string name="dirac_headset_in_ear">Mi اِن-ایر</string>
+    <string name="dirac_headset_in_ear2">Mi ان-ایئر 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ان-ایئر (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ان-ایر پرو</string>
+    <string name="dirac_headset_piston_1">Mi پسٹن -1</string>
+    <string name="dirac_headset_piston_2">Mi پسٹن -2</string>
+    <string name="dirac_headset_piston_basic">بنیادی ایڈیشن</string>
+    <string name="dirac_headset_piston_color">کلر ایڈشن</string>
+    <string name="dirac_headset_piston_standard">معیاری ایڈیشن</string>
+    <string name="dirac_headset_piston_youth">یوتھ ایڈیشن</string>
+    <string name="dirac_headset_reduction_noise">Mi شور منسوخی ٹائپ-C</string>
+    <string name="dirac_headset_title">ہیڈفون ی؛قسم منتخب کریں</string>
+    <string name="dirac_title">Mi ساؤنڈ انہینسر</string>
+    <string name="dirac_preset_title">پری سیٹ</string>
+</resources>

--- a/parts/res/values-ur-rPK/strings.xml
+++ b/parts/res/values-ur-rPK/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">بلیوز</string>
+    <string name="dirac_preset_classical">کلاسیکی</string>
+    <string name="dirac_preset_country">ملک</string>
+    <string name="dirac_preset_dance">رقص</string>
+    <string name="dirac_preset_electronic">الیکٹرونک</string>
+    <string name="dirac_default">ڈیفالٹ</string>
+    <string name="dirac_preset_jazz">جاز</string>
+    <string name="dirac_preset_metal">دھات</string>
+    <string name="dirac_preset_pop">پاپ</string>
+    <string name="dirac_preset_rock">راک</string>
+    <string name="dirac_headset_cancelling">Mi شور منسوخی 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi کیپسول</string>
+    <string name="dirac_headset_earbuds">Mi ایربڈز</string>
+    <string name="dirac_headset_general">عمومی</string>
+    <string name="dirac_headset_general_inear">عمومی ان-ایر</string>
+    <string name="dirac_headset_half_in_ear">Mi ہاف ان ایئر</string>
+    <string name="dirac_headset_headphone">Mi ہیڈ فونز</string>
+    <string name="dirac_headset_comfort">Mi کمفرٹ</string>
+    <string name="dirac_headset_in_ear">Mi اِن-ایر</string>
+    <string name="dirac_headset_in_ear2">Mi ان-ایئر 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi ان-ایئر (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi ان-ایر پرو</string>
+    <string name="dirac_headset_piston_1">Mi پسٹن -1</string>
+    <string name="dirac_headset_piston_2">Mi پسٹن -2</string>
+    <string name="dirac_headset_piston_basic">بنیادی ایڈیشن</string>
+    <string name="dirac_headset_piston_color">کلر ایڈشن</string>
+    <string name="dirac_headset_piston_standard">معیاری ایڈیشن</string>
+    <string name="dirac_headset_piston_youth">یوتھ ایڈیشن</string>
+    <string name="dirac_headset_reduction_noise">Mi شور منسوخی ٹائپ-C</string>
+    <string name="dirac_headset_title">ہیڈفون ی؛قسم منتخب کریں</string>
+    <string name="dirac_title">Mi ساؤنڈ انہینسر</string>
+    <string name="dirac_preset_title">پری سیٹ</string>
+</resources>

--- a/parts/res/values-uz-rUZ/strings.xml
+++ b/parts/res/values-uz-rUZ/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blyuz</string>
+    <string name="dirac_preset_classical">Klassik</string>
+    <string name="dirac_preset_country">Mamlakat</string>
+    <string name="dirac_preset_dance">Raqs</string>
+    <string name="dirac_preset_electronic">Elektronik</string>
+    <string name="dirac_default">Standart</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Metall</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rok</string>
+    <string name="dirac_headset_cancelling">Mi Shovqinni Kamaytirish 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Kapsula</string>
+    <string name="dirac_headset_earbuds">Mi naushniklar</string>
+    <string name="dirac_headset_general">Umumiy</string>
+    <string name="dirac_headset_general_inear">Oddiy quloqliklar</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Mi Naushniklar</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi quloqliklari</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear(2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi quloqliklari Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi Porshen-2</string>
+    <string name="dirac_headset_piston_basic">Asosiy nashr</string>
+    <string name="dirac_headset_piston_color">Rangli nashr</string>
+    <string name="dirac_headset_piston_standard">Standart versiya</string>
+    <string name="dirac_headset_piston_youth">Yoshlar nashri</string>
+    <string name="dirac_headset_reduction_noise">Mi-shovqinni Kamaytirish C-turi</string>
+    <string name="dirac_headset_title">Naushniklar turi</string>
+    <string name="dirac_title">Mi Ovoz kuchaytirgichi</string>
+    <string name="dirac_preset_title">Tayyorlash</string>
+</resources>

--- a/parts/res/values-vi/strings.xml
+++ b/parts/res/values-vi/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">Blue</string>
+    <string name="dirac_preset_classical">Cổ điển</string>
+    <string name="dirac_preset_country">Quê hương</string>
+    <string name="dirac_preset_dance">Khiêu vũ</string>
+    <string name="dirac_preset_electronic">Điện tử</string>
+    <string name="dirac_default">Mặc định</string>
+    <string name="dirac_preset_jazz">Jazz</string>
+    <string name="dirac_preset_metal">Kim loại</string>
+    <string name="dirac_preset_pop">Pop</string>
+    <string name="dirac_preset_rock">Rock</string>
+    <string name="dirac_headset_cancelling">Khử tiếng ồn Mi 3.5mm</string>
+    <string name="dirac_headset_capsule">Mi Capsule</string>
+    <string name="dirac_headset_earbuds">Mi Earbud</string>
+    <string name="dirac_headset_general">Thường</string>
+    <string name="dirac_headset_general_inear">In-Ear thường</string>
+    <string name="dirac_headset_half_in_ear">Mi Half In-Ear</string>
+    <string name="dirac_headset_headphone">Tai nghe Mi</string>
+    <string name="dirac_headset_comfort">Mi Comfort</string>
+    <string name="dirac_headset_in_ear">Mi In-Ear</string>
+    <string name="dirac_headset_in_ear2">Mi In-Ear 2</string>
+    <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
+    <string name="dirac_headset_in_ear_pro">Mi In-Ear Pro</string>
+    <string name="dirac_headset_piston_1">Mi Piston-1</string>
+    <string name="dirac_headset_piston_2">Mi piston-2</string>
+    <string name="dirac_headset_piston_basic">Cơ bản</string>
+    <string name="dirac_headset_piston_color">Phiên bản sắc màu</string>
+    <string name="dirac_headset_piston_standard">Tiêu chuẩn</string>
+    <string name="dirac_headset_piston_youth">Phiên bản trẻ</string>
+    <string name="dirac_headset_reduction_noise">Khử tiếng ồn Mi Type-C</string>
+    <string name="dirac_headset_title">Chọn loại tai nghe</string>
+    <string name="dirac_title">Tăng cường Mi Sound</string>
+    <string name="dirac_preset_title">Cài đặt sẵn</string>
+</resources>

--- a/parts/res/values-zh-rCN/strings.xml
+++ b/parts/res/values-zh-rCN/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">布鲁斯</string>
+    <string name="dirac_preset_classical">古典</string>
+    <string name="dirac_preset_country">乡村</string>
+    <string name="dirac_preset_dance">舞曲</string>
+    <string name="dirac_preset_electronic">电子音乐</string>
+    <string name="dirac_default">无</string>
+    <string name="dirac_preset_jazz">爵士</string>
+    <string name="dirac_preset_metal">金属</string>
+    <string name="dirac_preset_pop">流行</string>
+    <string name="dirac_preset_rock">摇滚</string>
+    <string name="dirac_headset_cancelling">小米降噪 3.5mm</string>
+    <string name="dirac_headset_capsule">小米胶囊</string>
+    <string name="dirac_headset_earbuds">灵动耳塞式</string>
+    <string name="dirac_headset_general">通用</string>
+    <string name="dirac_headset_general_inear">通用入耳式</string>
+    <string name="dirac_headset_half_in_ear">小米半入耳式</string>
+    <string name="dirac_headset_headphone">小米头戴式</string>
+    <string name="dirac_headset_comfort">小米头戴轻松版</string>
+    <string name="dirac_headset_in_ear">小米圈铁</string>
+    <string name="dirac_headset_in_ear2">小米圈铁2</string>
+    <string name="dirac_headset_in_ear_2013">灵悦入耳式</string>
+    <string name="dirac_headset_in_ear_pro">小米圈铁Pro</string>
+    <string name="dirac_headset_piston_1">小米活塞1</string>
+    <string name="dirac_headset_piston_2">小米活塞2</string>
+    <string name="dirac_headset_piston_basic">小米活塞简装版</string>
+    <string name="dirac_headset_piston_color">小米活塞炫彩版</string>
+    <string name="dirac_headset_piston_standard">小米活塞标准版</string>
+    <string name="dirac_headset_piston_youth">小米活塞青春版</string>
+    <string name="dirac_headset_reduction_noise">小米降噪 typeC</string>
+    <string name="dirac_headset_title">耳机类型设置</string>
+    <string name="dirac_title">使用米音提升音质</string>
+    <string name="dirac_preset_title">听感</string>
+</resources>

--- a/parts/res/values-zh-rHK/strings.xml
+++ b/parts/res/values-zh-rHK/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">布魯斯</string>
+    <string name="dirac_preset_classical">古典</string>
+    <string name="dirac_preset_country">鄉村</string>
+    <string name="dirac_preset_dance">舞曲</string>
+    <string name="dirac_preset_electronic">電子音樂</string>
+    <string name="dirac_default">無</string>
+    <string name="dirac_preset_jazz">爵士</string>
+    <string name="dirac_preset_metal">金屬</string>
+    <string name="dirac_preset_pop">流行</string>
+    <string name="dirac_preset_rock">搖滾</string>
+    <string name="dirac_headset_cancelling">小米降噪耳機 3.5mm</string>
+    <string name="dirac_headset_capsule">小米膠囊</string>
+    <string name="dirac_headset_earbuds">靈動耳塞式</string>
+    <string name="dirac_headset_general">通用</string>
+    <string name="dirac_headset_general_inear">通用入耳式</string>
+    <string name="dirac_headset_half_in_ear">小米半入耳式</string>
+    <string name="dirac_headset_headphone">小米頭戴式</string>
+    <string name="dirac_headset_comfort">小米頭戴式耳機輕鬆版</string>
+    <string name="dirac_headset_in_ear">小米圈鐵耳機</string>
+    <string name="dirac_headset_in_ear2">小米圈鐵耳機2</string>
+    <string name="dirac_headset_in_ear_2013">靈悅入耳式</string>
+    <string name="dirac_headset_in_ear_pro">小米圈鐵耳機Pro</string>
+    <string name="dirac_headset_piston_1">小米活塞1</string>
+    <string name="dirac_headset_piston_2">小米活塞2</string>
+    <string name="dirac_headset_piston_basic">小米活塞簡裝版</string>
+    <string name="dirac_headset_piston_color">小米活塞耳機炫彩版</string>
+    <string name="dirac_headset_piston_standard">小米活塞標準版</string>
+    <string name="dirac_headset_piston_youth">小米活塞青春版</string>
+    <string name="dirac_headset_reduction_noise">小米降噪耳機 typeC</string>
+    <string name="dirac_headset_title">耳機類型設定</string>
+    <string name="dirac_title">使用米音提升音質</string>
+    <string name="dirac_preset_title">聽感</string>
+</resources>

--- a/parts/res/values-zh-rTW/strings.xml
+++ b/parts/res/values-zh-rTW/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="dirac_preset_blues">布魯斯</string>
+    <string name="dirac_preset_classical">古典</string>
+    <string name="dirac_preset_country">鄉村</string>
+    <string name="dirac_preset_dance">舞曲</string>
+    <string name="dirac_preset_electronic">電子音樂</string>
+    <string name="dirac_default">無</string>
+    <string name="dirac_preset_jazz">爵士</string>
+    <string name="dirac_preset_metal">金屬</string>
+    <string name="dirac_preset_pop">流行</string>
+    <string name="dirac_preset_rock">搖滾</string>
+    <string name="dirac_headset_cancelling">小米降噪耳機 3.5mm</string>
+    <string name="dirac_headset_capsule">小米膠囊</string>
+    <string name="dirac_headset_earbuds">靈動耳塞式</string>
+    <string name="dirac_headset_general">通用</string>
+    <string name="dirac_headset_general_inear">通用入耳式</string>
+    <string name="dirac_headset_half_in_ear">小米半入耳式</string>
+    <string name="dirac_headset_headphone">小米頭戴式</string>
+    <string name="dirac_headset_comfort">小米頭戴式耳機輕鬆版</string>
+    <string name="dirac_headset_in_ear">小米圈鐵耳機</string>
+    <string name="dirac_headset_in_ear2">小米圈鐵耳機2</string>
+    <string name="dirac_headset_in_ear_2013">靈悅入耳式</string>
+    <string name="dirac_headset_in_ear_pro">小米圈鐵耳機Pro</string>
+    <string name="dirac_headset_piston_1">小米活塞1</string>
+    <string name="dirac_headset_piston_2">小米活塞2</string>
+    <string name="dirac_headset_piston_basic">小米活塞簡裝版</string>
+    <string name="dirac_headset_piston_color">小米活塞耳機炫彩版</string>
+    <string name="dirac_headset_piston_standard">小米活塞標準版</string>
+    <string name="dirac_headset_piston_youth">小米活塞青春版</string>
+    <string name="dirac_headset_reduction_noise">小米降噪耳機 typeC</string>
+    <string name="dirac_headset_title">耳機類型設定</string>
+    <string name="dirac_title">使用米音提升音質</string>
+    <string name="dirac_preset_title">聽感</string>
+</resources>

--- a/parts/res/values/arrays.xml
+++ b/parts/res/values/arrays.xml
@@ -53,7 +53,6 @@
         <item>9</item>
         <item>10</item>
         <item>11</item>
-        <item>12</item>
         <item>13</item>
         <item>14</item>
         <item>15</item>

--- a/parts/res/values/arrays.xml
+++ b/parts/res/values/arrays.xml
@@ -16,7 +16,7 @@
 -->
 <resources>
     <!-- Values for Dirac headset pref -->
-    <string-array name="dirac_headset_pref_entries" translatable="false">
+    <string-array name="dirac_headset_pref_entries">
         <item>@string/dirac_default</item>
         <item>@string/dirac_headset_earbuds</item>
         <item>@string/dirac_headset_in_ear_2013</item>
@@ -67,7 +67,7 @@
     </string-array>
 
     <!-- Values for Dirac preset pref -->
-    <string-array name="dirac_preset_pref_entries" translatable="false">
+    <string-array name="dirac_preset_pref_entries">
         <item>@string/dirac_default</item>
         <item>@string/dirac_preset_rock</item>
         <item>@string/dirac_preset_jazz</item>

--- a/parts/res/values/arrays.xml
+++ b/parts/res/values/arrays.xml
@@ -17,7 +17,7 @@
 <resources>
     <!-- Values for Dirac headset pref -->
     <string-array name="dirac_headset_pref_entries" translatable="false">
-        <item>@string/dirac_headset_default</item>
+        <item>@string/dirac_default</item>
         <item>@string/dirac_headset_earbuds</item>
         <item>@string/dirac_headset_in_ear_2013</item>
         <item>@string/dirac_headset_piston_1</item>
@@ -68,7 +68,7 @@
 
     <!-- Values for Dirac preset pref -->
     <string-array name="dirac_preset_pref_entries" translatable="false">
-        <item>@string/dirac_preset_default</item>
+        <item>@string/dirac_default</item>
         <item>@string/dirac_preset_rock</item>
         <item>@string/dirac_preset_jazz</item>
         <item>@string/dirac_preset_pop</item>

--- a/parts/res/values/strings.xml
+++ b/parts/res/values/strings.xml
@@ -16,9 +16,9 @@
 -->
 <resources>
     <!-- Dirac settings -->
-    <string name="dirac_title">Dirac sound enhancer</string>
-    <string name="dirac_headset_title">Headset type</string>
-    <string name="dirac_preset_title">Sound preset</string>
+    <string name="dirac_title">Mi Sound Enhancer</string>
+    <string name="dirac_headset_title">Choose headphones type</string>
+    <string name="dirac_preset_title">Preset</string>
     <string name="dirac_default">Default</string>
 
     <!-- Dirac settings: headset types -->

--- a/parts/res/values/strings.xml
+++ b/parts/res/values/strings.xml
@@ -19,9 +19,9 @@
     <string name="dirac_title">Dirac sound enhancer</string>
     <string name="dirac_headset_title">Headset type</string>
     <string name="dirac_preset_title">Sound preset</string>
+    <string name="dirac_default">Default</string>
 
     <!-- Dirac settings: headset types -->
-    <string name="dirac_headset_default">Default</string>
     <string name="dirac_headset_earbuds">Mi Earbuds</string>
     <string name="dirac_headset_in_ear_2013">Mi In-Ear (2013)</string>
     <string name="dirac_headset_piston_1">Mi Piston 1</string>
@@ -45,7 +45,6 @@
     <string name="dirac_headset_earphone">Mi Earphones</string>
 
     <!-- Dirac settings: equalizer presets -->
-    <string name="dirac_preset_default">Default</string>
     <string name="dirac_preset_rock">Rock</string>
     <string name="dirac_preset_jazz">Jazz</string>
     <string name="dirac_preset_pop">Pop</string>

--- a/parts/src/org/lineageos/settings/dirac/DiracSound.java
+++ b/parts/src/org/lineageos/settings/dirac/DiracSound.java
@@ -27,7 +27,7 @@ public class DiracSound extends AudioEffect {
     private static final int DIRACSOUND_PARAM_MUSIC = 4;
 
     private static final UUID EFFECT_TYPE_DIRACSOUND =
-            UUID.fromString("e069d9e0-8329-11df-9168-0002a5d5c51b");
+            UUID.fromString("5b8e36a5-144a-4c38-b1d7-0002a5d5c51b");
     private static final String TAG = "DiracSound";
 
     public DiracSound(int priority, int audioSession) {

--- a/parts/src/org/lineageos/settings/dirac/DiracSound.java
+++ b/parts/src/org/lineageos/settings/dirac/DiracSound.java
@@ -17,7 +17,7 @@
 package org.lineageos.settings.dirac;
 
 import android.media.audiofx.AudioEffect;
-
+import android.util.Log;
 import java.util.UUID;
 
 public class DiracSound extends AudioEffect {
@@ -29,6 +29,7 @@ public class DiracSound extends AudioEffect {
     private static final UUID EFFECT_TYPE_DIRACSOUND =
             UUID.fromString("5b8e36a5-144a-4c38-b1d7-0002a5d5c51b");
     private static final String TAG = "DiracSound";
+    private static final boolean DEBUG = true;
 
     public DiracSound(int priority, int audioSession) {
         super(EFFECT_TYPE_NULL, EFFECT_TYPE_DIRACSOUND, priority, audioSession);
@@ -38,11 +39,13 @@ public class DiracSound extends AudioEffect {
             IllegalArgumentException, UnsupportedOperationException {
         int[] value = new int[1];
         checkStatus(getParameter(DIRACSOUND_PARAM_MUSIC, value));
+        if (DEBUG) Log.d(TAG, "getMusic() -> " + value[0]);
         return value[0];
     }
 
     public void setMusic(int enable) throws IllegalStateException,
             IllegalArgumentException, UnsupportedOperationException {
+        if (DEBUG) Log.d(TAG, "setMusic(" + enable + ")");
         checkStatus(setParameter(DIRACSOUND_PARAM_MUSIC, enable));
     }
 
@@ -50,11 +53,13 @@ public class DiracSound extends AudioEffect {
             IllegalArgumentException, UnsupportedOperationException {
         int[] value = new int[1];
         checkStatus(getParameter(DIRACSOUND_PARAM_HEADSET_TYPE, value));
+        if (DEBUG) Log.d(TAG, "getHeadsetType() -> " + value[0]);
         return value[0];
     }
 
     public void setHeadsetType(int type) throws IllegalStateException,
             IllegalArgumentException, UnsupportedOperationException {
+        if (DEBUG) Log.d(TAG, "setHeadsetType(" + type + ")");
         checkStatus(setParameter(DIRACSOUND_PARAM_HEADSET_TYPE, type));
     }
 
@@ -65,11 +70,14 @@ public class DiracSound extends AudioEffect {
         param[0] = DIRACSOUND_PARAM_EQ_LEVEL;
         param[1] = band;
         checkStatus(getParameter(param, value));
-        return new Float(new String(value)).floatValue();
+        float level = new Float(new String(value)).floatValue();
+        if (DEBUG) Log.d(TAG, "getLevel(" + band + ") -> " + level);
+        return level;
     }
 
     public void setLevel(int band, float level) throws IllegalStateException,
             IllegalArgumentException, UnsupportedOperationException {
+        if (DEBUG) Log.d(TAG, "setLevel(" + band + ", " + level + ")");
         checkStatus(setParameter(new int[]{DIRACSOUND_PARAM_EQ_LEVEL, band},
                 String.valueOf(level).getBytes()));
     }

--- a/parts/src/org/lineageos/settings/dirac/DiracUtils.java
+++ b/parts/src/org/lineageos/settings/dirac/DiracUtils.java
@@ -29,9 +29,6 @@ public final class DiracUtils {
     public static void initialize() {
         if (!mInitialized) {
             mDiracSound = new DiracSound(0, 0);
-            mDiracSound.setMusic(mDiracSound.getMusic());
-            mDiracSound.setHeadsetType(mDiracSound.getHeadsetType());
-            setLevel(getLevel());
             mInitialized = true;
         }
     }

--- a/parts/src/org/lineageos/settings/dirac/DiracUtils.java
+++ b/parts/src/org/lineageos/settings/dirac/DiracUtils.java
@@ -22,15 +22,12 @@ import android.util.Log;
 public final class DiracUtils {
 
     protected static DiracSound mDiracSound;
-    private static boolean mInitialized;
     private static final String TAG = "DiracUtils";
     private static final boolean DEBUG = true;
 
     public static void initialize() {
-        if (!mInitialized) {
+        if (mDiracSound == null)
             mDiracSound = new DiracSound(0, 0);
-            mInitialized = true;
-        }
     }
 
     protected static void setMusic(boolean enable) {

--- a/parts/src/org/lineageos/settings/dirac/DiracUtils.java
+++ b/parts/src/org/lineageos/settings/dirac/DiracUtils.java
@@ -17,11 +17,14 @@
 package org.lineageos.settings.dirac;
 
 import android.content.Context;
+import android.util.Log;
 
 public final class DiracUtils {
 
     protected static DiracSound mDiracSound;
     private static boolean mInitialized;
+    private static final String TAG = "DiracUtils";
+    private static final boolean DEBUG = true;
 
     public static void initialize() {
         if (!mInitialized) {
@@ -34,6 +37,7 @@ public final class DiracUtils {
     }
 
     protected static void setMusic(boolean enable) {
+        if (DEBUG) Log.d(TAG, "setMusic(" + enable + ")");
         mDiracSound.setMusic(enable ? 1 : 0);
     }
 
@@ -44,6 +48,7 @@ public final class DiracUtils {
     protected static void setLevel(String preset) {
         String[] level = preset.split("\\s*,\\s*");
 
+        if (DEBUG) Log.d(TAG, "setLevel(" + preset + ")");
         for (int band = 0; band <= level.length - 1; band++) {
             mDiracSound.setLevel(band, Float.valueOf(level[band]));
         }
@@ -56,10 +61,12 @@ public final class DiracUtils {
             selected += String.valueOf(temp);
             if (band != 6) selected += ",";
         }
+        if (DEBUG) Log.d(TAG, "getLevel() -> " + selected);
         return selected;
     }
 
     protected static void setHeadsetType(int paramInt) {
+         if (DEBUG) Log.d(TAG, "setHeadsetType(" + paramInt + ")");
          mDiracSound.setHeadsetType(paramInt);
     }
 }

--- a/parts/src/org/lineageos/settings/dirac/DiracUtils.java
+++ b/parts/src/org/lineageos/settings/dirac/DiracUtils.java
@@ -51,17 +51,6 @@ public final class DiracUtils {
         }
     }
 
-    protected static String getLevel() {
-        String selected = "";
-        for (int band = 0; band <= 6; band++) {
-            int temp = (int) mDiracSound.getLevel(band);
-            selected += String.valueOf(temp);
-            if (band != 6) selected += ",";
-        }
-        if (DEBUG) Log.d(TAG, "getLevel() -> " + selected);
-        return selected;
-    }
-
     protected static void setHeadsetType(int paramInt) {
          if (DEBUG) Log.d(TAG, "setHeadsetType(" + paramInt + ")");
          mDiracSound.setHeadsetType(paramInt);


### PR DESCRIPTION
The series reimplements Dirac implementation using MiSoundFX module.

Do not forget to set property `ro.vendor.audio.soundfx.type=mi` that could be later commonized after verification.

Details:
Patch 1 - adds misoundfx effect entry into audio_effects.xml
Patch 2 - changes XiaomiParts to use misoundfx UUID instead of dirac one
Patch 3 - adds logging facility for sound enhancer to ease debugging
Patch 4 - removes unneeded initialization of sound effect (this is done by effect itself)
Patch 5 - removes unused method
Patch 6 - minor simplification
Patch 7 - removes superfluous headset id from list
Patch 8 - commonizes "Default" word
Patch 9 - full localization
Patch 10 - removes unused dirac effect entry from audio_effects.xml