### PR TITLE
sdm710-common: make directories for tftp_server

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -259,6 +259,8 @@ on post-fs-data
 
     # Create directory for tftp
     mkdir /data/vendor/tombstones/rfs 0771 system system
+    mkdir /mnt/vendor/persist/rfs 0770 vendor_rfs vendor_rfs
+    mkdir /mnt/vendor/persist/hlos_rfs 0770 vendor_rfs vendor_rfs
 
     mkdir /data/vendor/ramdump 0771 root system
     mkdir /data/vendor/bluetooth 0770 bluetooth bluetooth


### PR DESCRIPTION
If persist partition is restored from stock there are missing
directories 'rfs' and 'hlos_rfs'. Service tftp_service tries
to create in runtime but this attempt fails (Permission denied).
Although service should run under as root it sets its UID and GID
to vendor_rfs (2903) and it is unable to create directories
under /mnt/persist.

Change-Id: I31d89192a6d2489e041ca84718c2261017348e10
Signed-off-by: Ivan Vecera <ivan@cera.cz>