### PR TITLE
Rename property vendor.bluetooth.soc to fix FM radio

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -16,7 +16,6 @@ persist.vendor.btstack.enable.twsplus=true
 persist.vendor.btstack.enable.twsplussho=true
 ro.bluetooth.a2dp_offload.supported=true
 ro.bluetooth.library_name=libbluetooth_qti.so
-vendor.bluetooth.soc=cherokee
 
 # Camera
 camera.disable_zsl_mode=true

--- a/vendor.prop
+++ b/vendor.prop
@@ -98,6 +98,7 @@ persist.vendor.qcom.bluetooth.a2dp_offload_cap=sbc-aptx-aptxtws-aptxhd-aac-ldac
 persist.vendor.qcom.bluetooth.aac_frm_ctl.enabled=true
 persist.vendor.qcom.bluetooth.twsp_state.enabled=false
 persist.vendor.qcom.bluetooth.soc=cherokee
+vendor.qcom.bluetooth.soc=cherokee
 
 # Charger
 ro.charger.enable_suspend=true


### PR DESCRIPTION
FM App after commit [1] uses different property to detect Cherokee
SoC.

[1] https://github.com/LineageOS/android_vendor_qcom_opensource_fm-commonsys/commit/d759311529f2d660468eb14d3c5c67aa8e5eadf3
