### PR TITLE
Use new FOD, HBM and DC dimming implementation in kernel

### DIFF
--- a/fod/Android.bp
+++ b/fod/Android.bp
@@ -41,4 +41,7 @@ cc_library_static {
     include_dirs: [
         "frameworks/native/services/surfaceflinger/CompositionEngine/include"
     ],
+    header_libs: [
+        "generated_kernel_headers",
+    ],
 }

--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -30,10 +30,6 @@
 #define PARAM_NIT_630_FOD 1
 #define PARAM_NIT_NONE 0
 
-#define DISPPARAM_PATH "/sys/devices/platform/soc/ae00000.qcom,mdss_mdp/drm/card0/card0-DSI-1/disp_param"
-#define DISPPARAM_HBM_FOD_ON "0x20000"
-#define DISPPARAM_HBM_FOD_OFF "0xE0000"
-
 #define FOD_STATUS_PATH "/sys/devices/virtual/touch/tp_dev/fod_status"
 #define FOD_STATUS_ON 1
 #define FOD_STATUS_OFF 0
@@ -136,13 +132,11 @@ Return<void> FingerprintInscreen::onFinishEnroll() {
 }
 
 Return<void> FingerprintInscreen::onPress() {
-    set(DISPPARAM_PATH, DISPPARAM_HBM_FOD_ON);
     xiaomiFingerprintService->extCmd(COMMAND_NIT, PARAM_NIT_630_FOD);
     return Void();
 }
 
 Return<void> FingerprintInscreen::onRelease() {
-    set(DISPPARAM_PATH, DISPPARAM_HBM_FOD_OFF);
     xiaomiFingerprintService->extCmd(COMMAND_NIT, PARAM_NIT_NONE);
     return Void();
 }
@@ -171,16 +165,8 @@ Return<void> FingerprintInscreen::setLongPressEnabled(bool) {
     return Void();
 }
 
-Return<int32_t> FingerprintInscreen::getDimAmount(int32_t brightness) {
-    float alpha;
-
-    if (brightness > 62) {
-        alpha = 1.0 - pow(brightness / 255.0 * 430.0 / 600.0, 0.45);
-    } else {
-        alpha = 1.0 - pow(brightness / 200.0, 0.45);
-    }
-
-    return 255 * alpha;
+Return<int32_t> FingerprintInscreen::getDimAmount(int32_t) {
+    return 0;
 }
 
 Return<bool> FingerprintInscreen::shouldBoostBrightness() {

--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -152,12 +152,12 @@ Return<void> FingerprintInscreen::onHideFODView() {
 }
 
 Return<bool> FingerprintInscreen::handleAcquired(int32_t acquiredInfo, int32_t vendorCode) {
-    LOG(ERROR) << "acquiredInfo: " << acquiredInfo << ", vendorCode: " << vendorCode << "\n";
+    LOG(ERROR) << "acquiredInfo: " << acquiredInfo << ", vendorCode: " << vendorCode;
     return false;
 }
 
 Return<bool> FingerprintInscreen::handleError(int32_t error, int32_t vendorCode) {
-    LOG(ERROR) << "error: " << error << ", vendorCode: " << vendorCode << "\n";
+    LOG(ERROR) << "error: " << error << ", vendorCode: " << vendorCode;
     return false;
 }
 

--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -209,7 +209,7 @@ Return<bool> FingerprintInscreen::handleAcquired(int32_t acquiredInfo, int32_t v
     }
 
     if (acquiredInfo == FINGERPRINT_ACQUIRED_VENDOR) {
-        if (vendorCode == 0) {
+        if (vendorCode == 22) {
             Return<void> ret = mCallback->onFingerDown();
             if (!ret.isOk()) {
                 LOG(ERROR) << "FingerDown() error: " << ret.description();
@@ -217,7 +217,7 @@ Return<bool> FingerprintInscreen::handleAcquired(int32_t acquiredInfo, int32_t v
             return true;
         }
 
-        if (vendorCode == 1) {
+        if (vendorCode == 23) {
             Return<void> ret = mCallback->onFingerUp();
             if (!ret.isOk()) {
                 LOG(ERROR) << "FingerUp() error: " << ret.description();

--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -37,6 +37,10 @@
 #define PARAM_NIT_630_FOD 1
 #define PARAM_NIT_NONE 0
 
+#define FOD_PRESSED_PATH "/sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_pressed"
+#define FOD_PRESSED_ON 1
+#define FOD_PRESSED_OFF 0
+
 #define FOD_STATUS_PATH "/sys/devices/virtual/touch/tp_dev/fod_status"
 #define FOD_STATUS_ON 1
 #define FOD_STATUS_OFF 0
@@ -185,10 +189,12 @@ Return<void> FingerprintInscreen::onFinishEnroll() {
 }
 
 Return<void> FingerprintInscreen::onPress() {
+    set(FOD_PRESSED_PATH, FOD_PRESSED_ON);
     return Void();
 }
 
 Return<void> FingerprintInscreen::onRelease() {
+    set(FOD_PRESSED_PATH, FOD_PRESSED_OFF);
     return Void();
 }
 

--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -25,6 +25,11 @@
 
 #include <cmath>
 #include <fstream>
+#include <thread>
+
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/stat.h>
 
 #define COMMAND_NIT 10
 #define PARAM_NIT_630_FOD 1
@@ -33,6 +38,8 @@
 #define FOD_STATUS_PATH "/sys/devices/virtual/touch/tp_dev/fod_status"
 #define FOD_STATUS_ON 1
 #define FOD_STATUS_OFF 0
+
+#define FOD_UI_PATH "/sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_ui"
 
 #define FOD_DEFAULT_X 445
 #define FOD_DEFAULT_Y 1910
@@ -81,7 +88,26 @@ unexpected:
     return default_values;
 }
 
-}  // anonymous namespace
+static bool readBool(int fd) {
+    char c;
+    int rc;
+
+    rc = lseek(fd, 0, SEEK_SET);
+    if (rc) {
+        LOG(ERROR) << "failed to seek fd, err: " << rc;
+        return false;
+    }
+
+    rc = read(fd, &c, sizeof(char));
+    if (rc != 1) {
+        LOG(ERROR) << "failed to read bool from fd, err: " << rc;
+        return false;
+    }
+
+    return c != '0';
+}
+
+} // anonymous namespace
 
 namespace vendor {
 namespace lineage {
@@ -109,6 +135,31 @@ FingerprintInscreen::FingerprintInscreen() {
 
     LOG(INFO) << "FoD is located at " << fodPosX << "," << fodPosY
               << " with size " << fodSize << "pixels\n";
+
+    std::thread([this]() {
+        int fd = open(FOD_UI_PATH, O_RDONLY);
+        if (fd < 0) {
+            LOG(ERROR) << "failed to open fd, err: " << fd;
+            return;
+        }
+
+        struct pollfd fodUiPoll = {
+            .fd = fd,
+            .events = POLLERR | POLLPRI,
+            .revents = 0,
+        };
+
+        while (true) {
+            int rc = poll(&fodUiPoll, 1, -1);
+            if (rc < 0) {
+                LOG(ERROR) << "failed to poll fd, err: " << rc;
+                continue;
+            }
+
+            xiaomiFingerprintService->extCmd(COMMAND_NIT,
+                    readBool(fd) ? PARAM_NIT_630_FOD : PARAM_NIT_NONE);
+        }
+    }).detach();
 }
 
 Return<int32_t> FingerprintInscreen::getPositionX() {
@@ -132,12 +183,10 @@ Return<void> FingerprintInscreen::onFinishEnroll() {
 }
 
 Return<void> FingerprintInscreen::onPress() {
-    xiaomiFingerprintService->extCmd(COMMAND_NIT, PARAM_NIT_630_FOD);
     return Void();
 }
 
 Return<void> FingerprintInscreen::onRelease() {
-    xiaomiFingerprintService->extCmd(COMMAND_NIT, PARAM_NIT_NONE);
     return Void();
 }
 

--- a/fod/FingerprintInscreen.cpp
+++ b/fod/FingerprintInscreen.cpp
@@ -31,6 +31,8 @@
 #include <poll.h>
 #include <sys/stat.h>
 
+#define FINGERPRINT_ACQUIRED_VENDOR 6
+
 #define COMMAND_NIT 10
 #define PARAM_NIT_630_FOD 1
 #define PARAM_NIT_NONE 0
@@ -201,7 +203,29 @@ Return<void> FingerprintInscreen::onHideFODView() {
 }
 
 Return<bool> FingerprintInscreen::handleAcquired(int32_t acquiredInfo, int32_t vendorCode) {
-    LOG(ERROR) << "acquiredInfo: " << acquiredInfo << ", vendorCode: " << vendorCode;
+    std::lock_guard<std::mutex> _lock(mCallbackLock);
+    if (mCallback == nullptr) {
+        return false;
+    }
+
+    if (acquiredInfo == FINGERPRINT_ACQUIRED_VENDOR) {
+        if (vendorCode == 0) {
+            Return<void> ret = mCallback->onFingerDown();
+            if (!ret.isOk()) {
+                LOG(ERROR) << "FingerDown() error: " << ret.description();
+            }
+            return true;
+        }
+
+        if (vendorCode == 1) {
+            Return<void> ret = mCallback->onFingerUp();
+            if (!ret.isOk()) {
+                LOG(ERROR) << "FingerUp() error: " << ret.description();
+            }
+            return true;
+        }
+    }
+
     return false;
 }
 
@@ -222,7 +246,12 @@ Return<bool> FingerprintInscreen::shouldBoostBrightness() {
     return false;
 }
 
-Return<void> FingerprintInscreen::setCallback(const sp<IFingerprintInscreenCallback>& /* callback */) {
+Return<void> FingerprintInscreen::setCallback(const sp<IFingerprintInscreenCallback>& callback) {
+    {
+        std::lock_guard<std::mutex> _lock(mCallbackLock);
+        mCallback = callback;
+    }
+
     return Void();
 }
 

--- a/fod/FingerprintInscreen.h
+++ b/fod/FingerprintInscreen.h
@@ -55,6 +55,9 @@ class FingerprintInscreen : public IFingerprintInscreen {
   private:
     sp<IXiaomiFingerprint> xiaomiFingerprintService;
     int32_t fodPosX, fodPosY, fodSize;
+
+    std::mutex mCallbackLock;
+    sp<IFingerprintInscreenCallback> mCallback;
 };
 
 }  // namespace implementation

--- a/fod/FodExtension.cpp
+++ b/fod/FodExtension.cpp
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
+#include <drm/sde_drm.h>
 #include <compositionengine/FodExtension.h>
 
 uint32_t getFodZOrder(uint32_t z, bool touched) {
     if (touched) {
-        z |= 0x20000000u;
+        z |= FOD_PRESSED_LAYER_ZORDER;
     }
 
     return z;

--- a/fod/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710.rc
+++ b/fod/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710.rc
@@ -1,5 +1,8 @@
 on boot
+    chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_ui
     chown system system /sys/devices/virtual/touch/tp_dev/fod_status
+
+    chmod 0444 /sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_ui
     chmod 0644 /sys/devices/virtual/touch/tp_dev/fod_status
 
 service fingerprint-inscreen-1-0 /vendor/bin/hw/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710

--- a/fod/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710.rc
+++ b/fod/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710.rc
@@ -1,6 +1,5 @@
 on boot
     chown system system /sys/devices/virtual/touch/tp_dev/fod_status
-
     chmod 0644 /sys/devices/virtual/touch/tp_dev/fod_status
 
 service fingerprint-inscreen-1-0 /vendor/bin/hw/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710

--- a/fod/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710.rc
+++ b/fod/vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710.rc
@@ -1,7 +1,9 @@
 on boot
+    chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_pressed
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_ui
     chown system system /sys/devices/virtual/touch/tp_dev/fod_status
 
+    chmod 0644 /sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_pressed
     chmod 0444 /sys/devices/platform/soc/soc:qcom,dsi-display-primary/fod_ui
     chmod 0644 /sys/devices/virtual/touch/tp_dev/fod_status
 

--- a/livedisplay/Android.bp
+++ b/livedisplay/Android.bp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2019-2020 The LineageOS Project
+// Copyright (C) 2019-2021 The LineageOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ cc_binary {
     srcs: [
         ":vendor.lineage.livedisplay@2.0-sdm-pa",
         ":vendor.lineage.livedisplay@2.0-sdm-utils",
+        "AntiFlicker.cpp",
         "SunlightEnhancement.cpp",
         "service.cpp",
     ],

--- a/livedisplay/Android.bp
+++ b/livedisplay/Android.bp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2019 The LineageOS Project
+// Copyright (C) 2019-2020 The LineageOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ cc_binary {
     defaults: ["hidl_defaults"],
     relative_install_path: "hw",
     srcs: [
+        ":vendor.lineage.livedisplay@2.0-sdm-pa",
+        ":vendor.lineage.livedisplay@2.0-sdm-utils",
         "SunlightEnhancement.cpp",
         "service.cpp",
     ],
@@ -29,5 +31,8 @@ cc_binary {
         "libhidlbase",
         "libutils",
         "vendor.lineage.livedisplay@2.0",
+    ],
+    header_libs: [
+        "vendor.lineage.livedisplay@2.0-sdm-headers",
     ],
 }

--- a/livedisplay/Android.bp
+++ b/livedisplay/Android.bp
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 cc_binary {
-    name: "vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710",
-    init_rc: ["vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.rc"],
-    vintf_fragments: ["vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.xml"],
+    name: "vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710",
+    init_rc: ["vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc"],
+    vintf_fragments: ["vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.xml"],
     defaults: ["hidl_defaults"],
     relative_install_path: "hw",
     srcs: [
@@ -32,6 +32,7 @@ cc_binary {
         "libhidlbase",
         "libutils",
         "vendor.lineage.livedisplay@2.0",
+        "vendor.lineage.livedisplay@2.1",
     ],
     header_libs: [
         "vendor.lineage.livedisplay@2.0-sdm-headers",

--- a/livedisplay/Android.bp
+++ b/livedisplay/Android.bp
@@ -16,6 +16,7 @@
 cc_binary {
     name: "vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710",
     init_rc: ["vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.rc"],
+    vintf_fragments: ["vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.xml"],
     defaults: ["hidl_defaults"],
     relative_install_path: "hw",
     srcs: [

--- a/livedisplay/AntiFlicker.cpp
+++ b/livedisplay/AntiFlicker.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "AntiFlickerService"
+
+#include "AntiFlicker.h"
+
+#include <android-base/logging.h>
+#include <android-base/properties.h>
+#include <android-base/strings.h>
+#include <utils/Errors.h>
+#include <fstream>
+
+namespace vendor {
+namespace lineage {
+namespace livedisplay {
+namespace V2_1 {
+namespace implementation {
+
+static constexpr const char* kDcDimmingPath =
+        "/sys/devices/platform/soc/soc:qcom,dsi-display-primary/dc_dimming";
+
+bool AntiFlicker::isSupported() {
+    std::ofstream dc_dimming_file(kDcDimmingPath);
+    if (!dc_dimming_file.is_open()) {
+        LOG(ERROR) << "Failed to open " << kDcDimmingPath << ", error="
+                   << errno << " (" << strerror(errno) << ")";
+    }
+
+    return !dc_dimming_file.fail();
+}
+
+Return<bool> AntiFlicker::isEnabled() {
+    std::ifstream dc_dimming_file(kDcDimmingPath);
+    int result = -1;
+    dc_dimming_file >> result;
+    return !dc_dimming_file.fail() && result > 0;
+}
+
+Return<bool> AntiFlicker::setEnabled(bool enabled) {
+    std::ofstream dc_dimming_file(kDcDimmingPath);
+    dc_dimming_file << (enabled ? '1' : '0');
+    LOG(DEBUG) << "setEnabled fail " << dc_dimming_file.fail();
+    return !dc_dimming_file.fail();
+}
+
+}  // namespace implementation
+}  // namespace V2_1
+}  // namespace livedisplay
+}  // namespace lineage
+}  // namespace vendor

--- a/livedisplay/AntiFlicker.h
+++ b/livedisplay/AntiFlicker.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VENDOR_LINEAGE_LIVEDISPLAY_V2_1_ANTIFLICKER_H
+#define VENDOR_LINEAGE_LIVEDISPLAY_V2_1_ANTIFLICKER_H
+
+#include <hidl/MQDescriptor.h>
+#include <hidl/Status.h>
+#include <vendor/lineage/livedisplay/2.1/IAntiFlicker.h>
+
+namespace vendor {
+namespace lineage {
+namespace livedisplay {
+namespace V2_1 {
+namespace implementation {
+
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+using ::android::sp;
+
+class AntiFlicker : public IAntiFlicker {
+  public:
+    bool isSupported();
+
+    // Methods from ::vendor::lineage::livedisplay::V2_1::IAntiFlicker follow.
+    Return<bool> isEnabled() override;
+    Return<bool> setEnabled(bool enabled) override;
+};
+
+}  // namespace implementation
+}  // namespace V2_0
+}  // namespace livedisplay
+}  // namespace lineage
+}  // namespace vendor
+
+#endif  // VENDOR_LINEAGE_LIVEDISPLAY_V2_1_ANTIFLICKER_H

--- a/livedisplay/SunlightEnhancement.cpp
+++ b/livedisplay/SunlightEnhancement.cpp
@@ -28,7 +28,7 @@
 namespace vendor {
 namespace lineage {
 namespace livedisplay {
-namespace V2_0 {
+namespace V2_1 {
 namespace implementation {
 
 static constexpr const char* kHbmPath =
@@ -59,7 +59,7 @@ Return<bool> SunlightEnhancement::setEnabled(bool enabled) {
 }
 
 }  // namespace implementation
-}  // namespace V2_0
+}  // namespace V2_1
 }  // namespace livedisplay
 }  // namespace lineage
 }  // namespace vendor

--- a/livedisplay/SunlightEnhancement.h
+++ b/livedisplay/SunlightEnhancement.h
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#ifndef VENDOR_LINEAGE_LIVEDISPLAY_V2_0_SUNLIGHTENHANCEMENT_H
-#define VENDOR_LINEAGE_LIVEDISPLAY_V2_0_SUNLIGHTENHANCEMENT_H
+#ifndef VENDOR_LINEAGE_LIVEDISPLAY_V2_1_SUNLIGHTENHANCEMENT_H
+#define VENDOR_LINEAGE_LIVEDISPLAY_V2_1_SUNLIGHTENHANCEMENT_H
 
 #include <hidl/MQDescriptor.h>
 #include <hidl/Status.h>
-#include <vendor/lineage/livedisplay/2.0/ISunlightEnhancement.h>
+#include <vendor/lineage/livedisplay/2.1/ISunlightEnhancement.h>
 
 namespace vendor {
 namespace lineage {
 namespace livedisplay {
-namespace V2_0 {
+namespace V2_1 {
 namespace implementation {
 
 using ::android::hardware::Return;
@@ -35,15 +35,15 @@ class SunlightEnhancement : public ISunlightEnhancement {
   public:
     bool isSupported();
 
-    // Methods from ::vendor::lineage::livedisplay::V2_0::ISunlightEnhancement follow.
+    // Methods from ::vendor::lineage::livedisplay::V2_1::ISunlightEnhancement follow.
     Return<bool> isEnabled() override;
     Return<bool> setEnabled(bool enabled) override;
 };
 
 }  // namespace implementation
-}  // namespace V2_0
+}  // namespace V2_1
 }  // namespace livedisplay
 }  // namespace lineage
 }  // namespace vendor
 
-#endif  // VENDOR_LINEAGE_LIVEDISPLAY_V2_0_SUNLIGHTENHANCEMENT_H
+#endif  // VENDOR_LINEAGE_LIVEDISPLAY_V2_1_SUNLIGHTENHANCEMENT_H

--- a/livedisplay/service.cpp
+++ b/livedisplay/service.cpp
@@ -34,18 +34,12 @@ using ::vendor::lineage::livedisplay::V2_0::ISunlightEnhancement;
 using ::vendor::lineage::livedisplay::V2_0::implementation::SunlightEnhancement;
 
 int main() {
-    sp<SunlightEnhancement> sunlightEnhancement;
+    sp<SunlightEnhancement> sunlightEnhancement = new SunlightEnhancement();
     std::shared_ptr<SDMController> controller = std::make_shared<SDMController>();
     status_t status = OK;
 
     LOG(INFO) << "LiveDisplay HAL custom service is starting.";
 
-    sunlightEnhancement = new SunlightEnhancement();
-    if (sunlightEnhancement == nullptr) {
-        LOG(ERROR) << "Can not create an instance of LiveDisplay HAL SunlightEnhancement Iface,"
-                   << "exiting.";
-        goto shutdown;
-    }
 
     if (!sunlightEnhancement->isSupported()) {
         LOG(ERROR) << "SunlightEnhancement Iface is not supported, gracefully bailing out.";

--- a/livedisplay/service.cpp
+++ b/livedisplay/service.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#define LOG_TAG "lineage.livedisplay@2.0-service.xiaomi_sdm710"
+#define LOG_TAG "lineage.livedisplay@2.1-service.xiaomi_sdm710"
 
 #include <android-base/logging.h>
 #include <binder/ProcessState.h>
@@ -30,8 +30,8 @@ using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
 
 using ::vendor::lineage::livedisplay::V2_0::sdm::SDMController;
-using ::vendor::lineage::livedisplay::V2_0::ISunlightEnhancement;
-using ::vendor::lineage::livedisplay::V2_0::implementation::SunlightEnhancement;
+using ::vendor::lineage::livedisplay::V2_1::ISunlightEnhancement;
+using ::vendor::lineage::livedisplay::V2_1::implementation::SunlightEnhancement;
 
 int main() {
     sp<SunlightEnhancement> sunlightEnhancement = new SunlightEnhancement();

--- a/livedisplay/service.cpp
+++ b/livedisplay/service.cpp
@@ -21,6 +21,7 @@
 #include <hidl/HidlTransportSupport.h>
 
 #include "SunlightEnhancement.h"
+#include "livedisplay/sdm/SDMController.h"
 
 using android::OK;
 using android::sp;
@@ -28,12 +29,14 @@ using android::status_t;
 using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
 
+using ::vendor::lineage::livedisplay::V2_0::sdm::SDMController;
 using ::vendor::lineage::livedisplay::V2_0::ISunlightEnhancement;
 using ::vendor::lineage::livedisplay::V2_0::implementation::SunlightEnhancement;
 
 int main() {
     sp<SunlightEnhancement> sunlightEnhancement;
-    status_t status;
+    std::shared_ptr<SDMController> controller = std::make_shared<SDMController>();
+    status_t status = OK;
 
     LOG(INFO) << "LiveDisplay HAL custom service is starting.";
 

--- a/livedisplay/vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.rc
+++ b/livedisplay/vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.rc
@@ -1,6 +1,5 @@
 on boot
-    chown system system /sys/devices/platform/soc/ae00000.qcom,mdss_mdp/drm/card0/card0-DSI-1/disp_param
-    chown system system /sys/devices/platform/soc/ae00000.qcom,mdss_mdp/drm/card0/card0-DSI-1/hbm_status
+    chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/hbm
 
 service vendor.livedisplay-hal-2-0 /vendor/bin/hw/vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710
     class hal

--- a/livedisplay/vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.xml
+++ b/livedisplay/vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710.xml
@@ -1,0 +1,19 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IDisplayModes</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IPictureAdjustment</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>ISunlightEnhancement</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc
+++ b/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc
@@ -1,7 +1,7 @@
 on boot
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/hbm
 
-service vendor.livedisplay-hal-2-0 /vendor/bin/hw/vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710
+service vendor.livedisplay-hal-2-1 /vendor/bin/hw/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710
     class hal
     user system
     group system

--- a/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc
+++ b/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc
@@ -1,4 +1,5 @@
 on boot
+    chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/dc_dimming
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/hbm
 
 service vendor.livedisplay-hal-2-1 /vendor/bin/hw/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710

--- a/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc
+++ b/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.rc
@@ -1,4 +1,4 @@
-on boot
+on init
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/dc_dimming
     chown system system /sys/devices/platform/soc/soc:qcom,dsi-display-primary/hbm
 

--- a/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.xml
+++ b/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.xml
@@ -4,6 +4,10 @@
         <transport>hwbinder</transport>
         <version>2.1</version>
         <interface>
+            <name>IAntiFlicker</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
             <name>IDisplayModes</name>
             <instance>default</instance>
         </interface>

--- a/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.xml
+++ b/livedisplay/vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>vendor.lineage.livedisplay</name>
         <transport>hwbinder</transport>
-        <version>2.0</version>
+        <version>2.1</version>
         <interface>
             <name>IDisplayModes</name>
             <instance>default</instance>
@@ -15,5 +15,6 @@
             <name>ISunlightEnhancement</name>
             <instance>default</instance>
         </interface>
+        <fqname>@2.0::IPictureAdjustment/default</fqname>
     </hal>
 </manifest>

--- a/manifest.xml
+++ b/manifest.xml
@@ -306,23 +306,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </interface>
     </hal>
     <hal format="hidl">
-        <name>vendor.lineage.livedisplay</name>
-        <transport>hwbinder</transport>
-        <version>2.0</version>
-        <interface>
-            <name>IDisplayModes</name>
-            <instance>default</instance>
-        </interface>
-        <interface>
-            <name>IPictureAdjustment</name>
-            <instance>default</instance>
-        </interface>
-        <interface>
-            <name>ISunlightEnhancement</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>vendor.qti.data.factory</name>
         <transport>hwbinder</transport>
         <version>2.1</version>

--- a/sdm710.mk
+++ b/sdm710.mk
@@ -259,7 +259,8 @@ PRODUCT_PACKAGES += \
 
 # LiveDisplay
 PRODUCT_PACKAGES += \
-    vendor.lineage.livedisplay@2.0-service-sdm
+    vendor.lineage.livedisplay@2.0-service-sdm \
+    vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710
 
 # Media
 PRODUCT_PACKAGES += \

--- a/sdm710.mk
+++ b/sdm710.mk
@@ -260,7 +260,7 @@ PRODUCT_PACKAGES += \
 # LiveDisplay
 PRODUCT_PACKAGES += \
     vendor.lineage.livedisplay@2.0-service-sdm \
-    vendor.lineage.livedisplay@2.0-service.xiaomi_sdm710
+    vendor.lineage.livedisplay@2.1-service.xiaomi_sdm710
 
 # Media
 PRODUCT_PACKAGES += \

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -28,6 +28,9 @@
 /(vendor|system/vendor)/bin/mtd@1\.2             u:object_r:hal_mtdservice_default_exec:s0
 /(vendor|system/vendor)/bin/nv_mac               u:object_r:wcnss_service_exec:s0
 
+# FOD
+/sys/devices/platform/soc/soc:qcom,dsi-display.*/fod_ui u:object_r:sysfs_fod:s0
+
 # Fingerprint devices
 /dev/goodix_fp                                u:object_r:fingerprint_device:s0
 /dev/vfsspi                                   u:object_r:fingerprint_device:s0

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -65,7 +65,7 @@
 /(vendor|system/vendor)/bin/hw/android\.hardware\.light@2\.0-service\.xiaomi_sdm710                            u:object_r:hal_light_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power-service\.xiaomi-libperfmgr                                      u:object_r:hal_power_default_exec:s0
 /(vendor|system/vendor)/bin/hw/vendor\.lineage\.biometrics\.fingerprint\.inscreen@1.0-service\.xiaomi_sdm710   u:object_r:hal_lineage_fod_sdm710_exec:s0
-/(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.0-service\.xiaomi_sdm710                        u:object_r:hal_lineage_livedisplay_qti_exec:s0
+/(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.1-service\.xiaomi_sdm710                        u:object_r:hal_lineage_livedisplay_qti_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.ir@1\.0-service\.xiaomi                                      u:object_r:hal_ir_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power\.stats@1\.0-service\.mock			       u:object_r:hal_power_stats_default_exec:s0
 

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -29,6 +29,7 @@
 /(vendor|system/vendor)/bin/nv_mac               u:object_r:wcnss_service_exec:s0
 
 # FOD
+/sys/devices/platform/soc/soc:qcom,dsi-display.*/fod_pressed u:object_r:sysfs_fod:s0
 /sys/devices/platform/soc/soc:qcom,dsi-display.*/fod_ui u:object_r:sysfs_fod:s0
 
 # Fingerprint devices

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -46,8 +46,9 @@
 /sys/devices/platform/soc/[0-9]+\.spi/spi_master/spi[0-9]+/spi[0-9]+\.0/nstandby   u:object_r:sysfs_gps:s0
 
 # Graphics nodes
-/sys/class/kgsl(/.*)?                         u:object_r:sysfs_kgsl:s0
-/sys/devices/platform/soc/soc:qcom,dsi-display.*/hbm    u:object_r:sysfs_graphics:s0
+/sys/class/kgsl(/.*)?                                           u:object_r:sysfs_kgsl:s0
+/sys/devices/platform/soc/soc:qcom,dsi-display.*/dc_dimming     u:object_r:sysfs_graphics:s0
+/sys/devices/platform/soc/soc:qcom,dsi-display.*/hbm            u:object_r:sysfs_graphics:s0
 /sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/panel_info        u:object_r:sysfs_graphics:s0
 
 # Industrial I/O nodes

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -47,8 +47,7 @@
 
 # Graphics nodes
 /sys/class/kgsl(/.*)?                         u:object_r:sysfs_kgsl:s0
-/sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/disp_param        u:object_r:sysfs_graphics:s0
-/sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/hbm_status        u:object_r:sysfs_graphics:s0
+/sys/devices/platform/soc/soc:qcom,dsi-display.*/hbm    u:object_r:sysfs_graphics:s0
 /sys/devices/platform/soc/[a-z0-9]+.qcom,mdss_mdp/drm/card([0-3])+/card([0-3])+-DSI-1/panel_info        u:object_r:sysfs_graphics:s0
 
 # Industrial I/O nodes

--- a/sepolicy/vendor/genfs_contexts
+++ b/sepolicy/vendor/genfs_contexts
@@ -23,7 +23,6 @@ genfscon sysfs /devices/platform/soc/soc:fingerprint_fpc/irq                   u
 genfscon sysfs /devices/platform/soc/soc:fingerprint_fpc/wakeup_enable         u:object_r:sysfs_fingerprint:s0
 genfscon sysfs /devices/platform/soc/soc:fingerprint_goodix/proximity_state    u:object_r:sysfs_fingerprint:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,cpubw                            u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/platform/soc/soc:qcom,dsi-display-primary/fod_hbm      u:object_r:sysfs_fod:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,gpubw                            u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws/subsys2/restart_level    u:object_r:sysfs_ssr_toggle:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,kgsl-hyp/subsys3/restart_level   u:object_r:sysfs_ssr_toggle:s0


### PR DESCRIPTION
Userspace counter-part of kernel PR (https://github.com/SDM710-Development/android_kernel_xiaomi_sdm710/pull/12) that implements FOD handling, HBM and DC dimming from scratch.

Note that there are 2 commits that need to be applied to `android_hardware_qcom_display`:
https://github.com/ivecera/android_hardware_qcom_display/commit/0befc5e87c99156fdb44f656d575837b639af2f4
https://github.com/ivecera/android_hardware_qcom_display/commit/fd92a3c4d9fc5a8965a90c7392bb9a36a524f18e

These commits are currently missing in LineageOS upstream repository.