### PR TITLE
sdm710-common: Add missing display mode mappings

### DIFF
--- a/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
@@ -24,10 +24,13 @@
          "oldname:newname", one per entry. -->
     <string-array name="config_displayModeMappings" translatable="false">
         <item>38-default-OLED:standard</item>
+        <item>38oled_native:standard</item>
         <item>01-warm:reading</item>
         <item>02-cool:dynamic</item>
-        <item>P3_CE:dci_p3</item>
+        <item>P3_ce_0821:dci_p3</item>
+        <item>smart_MC:dci_p3</item>
         <item>srgb_d65:srgb</item>
+        <item>03srgb_d65:srgb</item>
     </string-array>
 
     <!-- Should we filter any display modes which are unampped? -->


### PR DESCRIPTION
Display mode mappings were inherited from sdm845-common and most
of them are used by Sirius. Pyxis uses different names so
color profiles menu item is missing in LiveDisplay.
Add missing display mode mappings for Pyxis and remove one not
used by any device.

Signed-off-by: Ivan Vecera <ivan@cera.cz>
Change-Id: Iad55bb32864bc52c2444639c994d465f8219b117